### PR TITLE
Fix highlighting for computed map keys

### DIFF
--- a/syntaxes/hcl.tmGrammar.json
+++ b/syntaxes/hcl.tmGrammar.json
@@ -488,7 +488,7 @@
               "name": "punctuation.section.parens.begin.hcl"
             }
           },
-          "end": "(\\))\\s*(\\=)\\s*",
+          "end": "(\\))\\s*(=|:)\\s*",
           "endCaptures": {
             "1": {
               "name": "punctuation.section.parens.end.hcl"

--- a/tests/snapshot/hcl/issue809.hcl
+++ b/tests/snapshot/hcl/issue809.hcl
@@ -1,0 +1,10 @@
+locals {
+  key_name = "testing"
+  test_example = {
+    (local.key_name): "test"
+  }
+}
+
+variable "test" {
+  default = "test"
+}

--- a/tests/snapshot/hcl/issue809.hcl.snap
+++ b/tests/snapshot/hcl/issue809.hcl.snap
@@ -1,0 +1,38 @@
+>locals {
+#^^^^^^ source.hcl meta.block.hcl entity.name.type.hcl
+#      ^ source.hcl meta.block.hcl
+#       ^ source.hcl meta.block.hcl punctuation.section.block.begin.hcl
+>  key_name = "testing"
+#^^ source.hcl meta.block.hcl
+#  ^^^^^^^^ source.hcl meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#          ^ source.hcl meta.block.hcl variable.declaration.hcl
+#           ^ source.hcl meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#            ^ source.hcl meta.block.hcl variable.declaration.hcl
+#             ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#              ^^^^^^^ source.hcl meta.block.hcl string.quoted.double.hcl
+#                     ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+>  test_example = {
+#^^ source.hcl meta.block.hcl
+#  ^^^^^^^^^^^^ source.hcl meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#              ^ source.hcl meta.block.hcl variable.declaration.hcl
+#               ^ source.hcl meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#                ^ source.hcl meta.block.hcl variable.declaration.hcl
+#                 ^ source.hcl meta.block.hcl meta.braces.hcl punctuation.section.braces.begin.hcl
+>    (local.key_name): "test"
+#^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl punctuation.section.parens.begin.hcl
+#     ^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl
+#          ^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl keyword.operator.accessor.hcl
+#           ^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.member.hcl
+#                   ^^^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl
+>  }
+#^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl
+>}
+#^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl
+>
+>variable "test" {
+#^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl
+>  default = "test"
+#^^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl
+>}
+#^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl
+>

--- a/tests/snapshot/hcl/issue809.hcl.snap
+++ b/tests/snapshot/hcl/issue809.hcl.snap
@@ -23,16 +23,33 @@
 #     ^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl
 #          ^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl keyword.operator.accessor.hcl
 #           ^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.member.hcl
-#                   ^^^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl
+#                   ^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl punctuation.section.parens.end.hcl
+#                    ^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl keyword.operator.hcl
+#                     ^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl
+#                      ^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                       ^^^^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl
+#                           ^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
 >  }
-#^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl
+#^^ source.hcl meta.block.hcl meta.braces.hcl
+#  ^ source.hcl meta.block.hcl meta.braces.hcl punctuation.section.braces.end.hcl
 >}
-#^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl
+#^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
 >
 >variable "test" {
-#^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl
+#^^^^^^^^ source.hcl meta.block.hcl entity.name.type.hcl
+#        ^ source.hcl meta.block.hcl
+#         ^^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#               ^ source.hcl meta.block.hcl
+#                ^ source.hcl meta.block.hcl punctuation.section.block.begin.hcl
 >  default = "test"
-#^^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl
+#^^ source.hcl meta.block.hcl
+#  ^^^^^^^ source.hcl meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#         ^ source.hcl meta.block.hcl variable.declaration.hcl
+#          ^ source.hcl meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#           ^ source.hcl meta.block.hcl variable.declaration.hcl
+#            ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#             ^^^^ source.hcl meta.block.hcl string.quoted.double.hcl
+#                 ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
 >}
-#^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl
+#^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
 >


### PR DESCRIPTION
This PR adds the missing `:` operator for computed map keys. Until now the `end` regex wasn't able to match anything and claimed the rest of the file as `meta.mapping.key`.
 
## Before
<img width="274" alt="CleanShot 2022-03-02 at 17 35 07@2x" src="https://user-images.githubusercontent.com/45985/156405914-1dd127ea-4469-4b6d-b53f-c7671aa89729.png">

## After
<img width="279" alt="CleanShot 2022-03-02 at 17 35 23@2x" src="https://user-images.githubusercontent.com/45985/156405923-b6f945e5-94fe-4b06-ac96-f5b7c5420b58.png">

Closes [#809](https://github.com/hashicorp/vscode-terraform/issues/809)