### PR TITLE
Release Automation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,25 @@
+changelog:
+  categories:
+    - title: NOTES
+      labels:
+        - note
+        - documentation
+    - title: FEATURES
+      labels:
+        - feature
+    - title: ENHANCEMENTS
+      labels:
+        - enhancement
+    - title: BUG FIXES
+      labels:
+        - bug
+    - title: INTERNAL
+      labels:
+        - dependencies
+        - "*"
+  exclude:
+    labels:
+      - duplicate
+      - wontfix
+      - question
+      - invalid

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Publish release
 
 permissions:
-  contents: write # for uploading release artifacts
+  contents: write # for creating a release and uploading release artifacts
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Publish release
+
+permissions:
+  contents: write # for uploading release artifacts
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+
+jobs:
+  release:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v3
+      - name: GH Release
+        run: |
+          gh release create "${GITHUB_REF#refs/tags/}" ./syntaxes/*.json --generate-notes
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,7 +8,7 @@ For example, you can download the `v0.2.3` Terraform Syntax release from `https:
 
 ## Increment Version
 
-1. Ensure that CHANGELOG.MD has all changes since last release. Add if any are missing.
+1. Ensure that `CHANGELOG.md` has all changes since last release. Add if any are missing.
 1. Increment `version` in package.json
 1. Commit changes
 1. Open PR

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,8 +2,7 @@
 
 This project produces GitHub Releases as the versioned artifacts for use in products like the Terraform VS Code Extension.
 
-For example, you can download the v0.2.3 Terraform Syntax release by using `
-https://github.com/hashicorp/syntax/releases/download/v0.2.3/terraform.tmGrammar.json`
+For example, you can download the `v0.2.3` Terraform Syntax release from `https://github.com/hashicorp/syntax/releases/download/v0.2.3/terraform.tmGrammar.json`
 
 ## Publish Release
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,34 @@
+# Release
+
+This project produces GitHub Releases as the versioned artifacts for use in products like the Terraform VS Code Extension.
+
+For example, you can download the v0.2.3 Terraform Syntax release by using `
+https://github.com/hashicorp/syntax/releases/download/v0.2.3/terraform.tmGrammar.json`
+
+## Publish Release
+
+## Increment Version
+
+1. Ensure that CHANGELOG.MD has all changes since last release. Add if any are missing.
+1. Increment `version` in package.json
+1. Commit changes
+1. Open PR
+1. Team reviews and merges PR
+
+## Create Release
+
+The Release GitHub Action will package the release for public consumption.
+
+To trigger a release, create a tag and push to the hashicorp/syntax repo:
+
+1. On the `main` branch create a new tag by running the following with the correct version:
+
+```
+  git tag -a v0.1.0 -m "v0.1.0"
+```
+
+2. Then push the tag to the repo to trigger the automation:
+
+```
+  git push --tags
+```


### PR DESCRIPTION
This adds a GitHub Action that packages up the syntax files for consumption in other products. The action is triggered by a git tag matching the version strategy we use and automatically generates a changelog inside the release based on all pull requests since last. A release document was added explaining the process.

A release would be downloaded using a URL like: `https://github.com/hashicorp/syntax/releases/download/v0.2.3/terraform.tmGrammar.json`

An example release looks like this:

![image](https://user-images.githubusercontent.com/272569/158216447-78d523e3-5857-449e-9002-4dde45ad2c85.png)

