### PR TITLE
Copy patterns from HCL grammar to Terraform grammar

### DIFF
--- a/syntaxes/terraform.tmGrammar.json
+++ b/syntaxes/terraform.tmGrammar.json
@@ -4,16 +4,100 @@
   "uuid": "d9db10d3-db70-48aa-8d44-f96ccbaa29f3",
   "fileTypes": ["tf", "tfvars"],
   "patterns": [
+    { "include": "#comments" },
+    { "include": "#attribute_definition" },
     { "include": "#block" },
-    { "include": "#functions" },
-    { "include": "#named_value_references" },
-    { "include": "source.hcl" }
+    { "include": "#expressions" }
   ],
   "repository": {
+    "char_escapes": {
+      "match": "\\\\[nrt\"\\\\]|\\\\u(\\h{8}|\\h{4})",
+      "comment": "Character Escapes",
+      "name": "constant.character.escape.hcl"
+    },
+    "comma": {
+      "match": "\\,",
+      "comment": "Commas - used in certain expressions",
+      "name": "punctuation.separator.hcl"
+    },
+    "language_constants": {
+      "match": "\\b(true|false|null)\\b",
+      "comment": "Language Constants",
+      "name": "constant.language.hcl"
+    },
     "named_value_references": {
       "match": "\\b(var|local|module|data|path|terraform)\\b",
       "comment": "Constant values available only to Terraform.",
       "name": "support.constant.terraform"
+    },
+    "local_identifiers": {
+      "match": "\\b(?!null|false|true)[[:alpha:]][[:alnum:]_-]*\\b",
+      "comment": "Local Identifiers",
+      "name": "variable.other.readwrite.hcl"
+    },
+    "hcl_type_keywords": {
+      "match": "\\b(any|string|number|bool)\\b",
+      "comment": "Type keywords known to HCL.",
+      "name": "storage.type.hcl"
+    },
+    "comments": {
+      "patterns": [
+        { "include": "#hash_line_comments" },
+        { "include": "#double_slash_line_comments" },
+        { "include": "#block_inline_comments" }
+      ]
+    },
+    "hash_line_comments": {
+      "name": "comment.line.number-sign.hcl",
+      "comment": "Line comments start with # sequence and end with the next newline sequence. A line comment is considered equivalent to a newline sequence",
+      "begin": "#",
+      "end": "$\\n?",
+      "captures": {
+        "0": {
+          "name": "punctuation.definition.comment.hcl"
+        }
+      }
+    },
+    "double_slash_line_comments": {
+      "name": "comment.line.double-slash.hcl",
+      "comment": "Line comments start with // sequence and end with the next newline sequence. A line comment is considered equivalent to a newline sequence",
+      "begin": "//",
+      "captures": {
+        "0": {
+          "name": "punctuation.definition.comment.hcl"
+        }
+      },
+      "end": "$\\n?"
+    },
+    "block_inline_comments": {
+      "name": "comment.block.hcl",
+      "comment": "Inline comments start with the /* sequence and end with the */ sequence, and may have any characters within except the ending sequence. An inline comment is considered equivalent to a whitespace sequence",
+      "begin": "/\\*",
+      "captures": {
+        "0": {
+          "name": "punctuation.definition.comment.hcl"
+        }
+      },
+      "end": "\\*/"
+    },
+    "attribute_definition": {
+      "match": "(\\()?((?!null|false|true)[[:alpha:]][[:alnum:]_-]*)(\\))?\\s*(\\=(?!\\=|\\>))\\s*",
+      "comment": "Identifier \"=\" with optional parens",
+      "name": "variable.declaration.hcl",
+      "captures": {
+        "1": {
+          "name": "punctuation.section.parens.begin.hcl"
+        },
+        "2": {
+          "name": "variable.other.readwrite.hcl"
+        },
+        "3": {
+          "name": "punctuation.section.parens.end.hcl"
+        },
+        "4": {
+          "name": "keyword.operator.assignment.hcl"
+        }
+      }
     },
     "block": {
       "name": "meta.block.hcl",
@@ -54,20 +138,656 @@
         }
       },
       "patterns": [
+        { "include": "#comments" },
+        { "include": "#attribute_definition" },
+        { "include": "#block" },
+        { "include": "#expressions" }
+      ]
+    },
+    "expressions": {
+      "patterns": [
         {
-          "include": "#block"
+          "include": "#literal_values"
         },
         {
-          "include": "source.hcl#comments"
+          "include": "#operators"
         },
         {
-          "include": "source.hcl#attribute_definition"
+          "include": "#tuple_for_expression"
         },
         {
-          "include": "source.hcl#block"
+          "include": "#object_for_expression"
         },
         {
-          "include": "source.hcl#expressions"
+          "include": "#brackets"
+        },
+        {
+          "include": "#objects"
+        },
+        {
+          "include": "#attribute_access"
+        },
+        {
+          "include": "#structural_types"
+        },
+        {
+          "include": "#functions"
+        },
+        {
+          "include": "#parens"
+        }
+      ]
+    },
+    "literal_values": {
+      "patterns": [
+        {
+          "include": "#numeric_literals"
+        },
+        {
+          "include": "#language_constants"
+        },
+        {
+          "include": "#string_literals"
+        },
+        {
+          "include": "#heredoc"
+        },
+        {
+          "include": "#hcl_type_keywords"
+        },
+        {
+          "include": "#named_value_references"
+        }
+      ]
+    },
+    "numeric_literals": {
+      "patterns": [
+        {
+          "match": "\\b\\d+([Ee][+-]?)\\d+\\b",
+          "comment": "Integer, no fraction, optional exponent",
+          "name": "constant.numeric.float.hcl",
+          "captures": {
+            "1": {
+              "name": "punctuation.separator.exponent.hcl"
+            }
+          }
+        },
+        {
+          "match": "\\b\\d+(\\.)\\d+(?:([Ee][+-]?)\\d+)?\\b",
+          "comment": "Integer, fraction, optional exponent",
+          "name": "constant.numeric.float.hcl",
+          "captures": {
+            "1": {
+              "name": "punctuation.separator.decimal.hcl"
+            },
+            "2": {
+              "name": "punctuation.separator.exponent.hcl"
+            }
+          }
+        },
+        {
+          "match": "\\b\\d+\\b",
+          "comment": "Integers",
+          "name": "constant.numeric.integer.hcl"
+        }
+      ]
+    },
+    "string_literals": {
+      "begin": "\"",
+      "comment": "Strings",
+      "name": "string.quoted.double.hcl",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.hcl"
+        }
+      },
+      "end": "\"",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.hcl"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#string_interpolation"
+        },
+        {
+          "include": "#char_escapes"
+        }
+      ]
+    },
+    "string_interpolation": {
+      "begin": "(\\G|[^%$])([%$]{)",
+      "comment": "String interpolation",
+      "name": "meta.interpolation.hcl",
+      "beginCaptures": {
+        "2": {
+          "name": "keyword.other.interpolation.begin.hcl"
+        }
+      },
+      "end": "\\}",
+      "endCaptures": {
+        "0": {
+          "name": "keyword.other.interpolation.end.hcl"
+        }
+      },
+      "patterns": [
+        {
+          "match": "\\~\\s",
+          "comment": "Trim left whitespace",
+          "name": "keyword.operator.template.left.trim.hcl"
+        },
+        {
+          "match": "\\s\\~",
+          "comment": "Trim right whitespace",
+          "name": "keyword.operator.template.right.trim.hcl"
+        },
+        {
+          "match": "\\b(if|else|endif|for|in|endfor)\\b",
+          "comment": "if/else/endif and for/in/endfor directives",
+          "name": "keyword.control.hcl"
+        },
+        {
+          "include": "#expressions"
+        },
+        {
+          "include": "#local_identifiers"
+        }
+      ]
+    },
+    "heredoc": {
+      "begin": "(\\<\\<\\-?)\\s*(\\w+)\\s*$",
+      "comment": "String Heredoc",
+      "name": "string.unquoted.heredoc.hcl",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.operator.heredoc.hcl"
+        },
+        "2": {
+          "name": "keyword.control.heredoc.hcl"
+        }
+      },
+      "end": "^\\s*\\2\\s*$",
+      "endCaptures": {
+        "0": {
+          "comment": "The heredoc token identifier (second capture above).",
+          "name": "keyword.control.heredoc.hcl"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#string_interpolation"
+        }
+      ]
+    },
+    "operators": {
+      "patterns": [
+        {
+          "match": "\\>\\=",
+          "name": "keyword.operator.hcl"
+        },
+        {
+          "match": "\\<\\=",
+          "name": "keyword.operator.hcl"
+        },
+        {
+          "match": "\\=\\=",
+          "name": "keyword.operator.hcl"
+        },
+        {
+          "match": "\\!\\=",
+          "name": "keyword.operator.hcl"
+        },
+        {
+          "match": "\\+",
+          "name": "keyword.operator.arithmetic.hcl"
+        },
+        {
+          "match": "\\-",
+          "name": "keyword.operator.arithmetic.hcl"
+        },
+        {
+          "match": "\\*",
+          "name": "keyword.operator.arithmetic.hcl"
+        },
+        {
+          "match": "\\/",
+          "name": "keyword.operator.arithmetic.hcl"
+        },
+        {
+          "match": "\\%",
+          "name": "keyword.operator.arithmetic.hcl"
+        },
+        {
+          "match": "\\&\\&",
+          "name": "keyword.operator.logical.hcl"
+        },
+        {
+          "match": "\\|\\|",
+          "name": "keyword.operator.logical.hcl"
+        },
+        {
+          "match": "\\!",
+          "name": "keyword.operator.logical.hcl"
+        },
+        {
+          "match": "\\>",
+          "name": "keyword.operator.hcl"
+        },
+        {
+          "match": "\\<",
+          "name": "keyword.operator.hcl"
+        },
+        {
+          "match": "\\?",
+          "name": "keyword.operator.hcl"
+        },
+        {
+          "match": "\\.\\.\\.",
+          "name": "keyword.operator.hcl"
+        },
+        {
+          "match": "\\:",
+          "scope": "keyword.operator.hcl"
+        }
+      ]
+    },
+    "brackets": {
+      "begin": "\\[",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.brackets.begin.hcl"
+        }
+      },
+      "end": "(\\*?)\\]",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.brackets.end.hcl"
+        },
+        "1": {
+          "name": "keyword.operator.splat.hcl"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#comma"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#inline_for_expression"
+        },
+        {
+          "include": "#inline_if_expression"
+        },
+        {
+          "include": "#expressions"
+        },
+        {
+          "include": "#local_identifiers"
+        }
+      ]
+    },
+    "objects": {
+      "name": "meta.braces.hcl",
+      "begin": "\\{",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.braces.begin.hcl"
+        }
+      },
+      "end": "\\}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.braces.end.hcl"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#objects"
+        },
+        {
+          "include": "#inline_for_expression"
+        },
+        {
+          "include": "#inline_if_expression"
+        },
+        {
+          "match": "\\b((?!null|false|true)[[:alpha:]][[:alnum:]_-]*)\\s*(\\=\\>?)\\s*",
+          "comment": "Literal, named object key",
+          "captures": {
+            "1": {
+              "name": "meta.mapping.key.hcl variable.other.readwrite.hcl"
+            },
+            "2": {
+              "name": "keyword.operator.assignment.hcl",
+              "patterns": [
+                {
+                  "match": "\\=\\>",
+                  "name": "storage.type.function.hcl"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "match": "\\b((\").*(\"))\\s*(\\=)\\s*",
+          "comment": "String object key",
+          "captures": {
+            "0": {
+              "patterns": [
+                {
+                  "include": "#named_value_references"
+                }
+              ]
+            },
+            "1": {
+              "name": "meta.mapping.key.hcl string.quoted.double.hcl"
+            },
+            "2": {
+              "name": "punctuation.definition.string.begin.hcl"
+            },
+            "3": {
+              "name": "punctuation.definition.string.end.hcl"
+            },
+            "4": {
+              "name": "keyword.operator.hcl"
+            }
+          }
+        },
+        {
+          "begin": "^\\s*\\(",
+          "comment": "Computed object key (any expression between parens)",
+          "name": "meta.mapping.key.hcl",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.section.parens.begin.hcl"
+            }
+          },
+          "end": "(\\))\\s*(\\=)\\s*",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.section.parens.end.hcl"
+            },
+            "2": {
+              "name": "keyword.operator.hcl"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#named_value_references"
+            },
+            {
+              "include": "#attribute_access"
+            }
+          ]
+        },
+        {
+          "include": "#object_key_values"
+        }
+      ]
+    },
+    "object_key_values": {
+      "patterns": [
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#literal_values"
+        },
+        {
+          "include": "#operators"
+        },
+        {
+          "include": "#tuple_for_expression"
+        },
+        {
+          "include": "#object_for_expression"
+        },
+        {
+          "include": "#heredoc"
+        },
+        {
+          "include": "#functions"
+        }
+      ]
+    },
+    "tuple_for_expression": {
+      "begin": "(\\[)\\s?(for)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.section.brackets.begin.hcl"
+        },
+        "2": {
+          "comment": "for expression (tuple)",
+          "name": "keyword.control.hcl"
+        }
+      },
+      "end": "\\]",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.brackets.end.hcl"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#for_expression_body"
+        }
+      ]
+    },
+    "object_for_expression": {
+      "begin": "(\\{)\\s?(for)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.section.braces.begin.hcl"
+        },
+        "2": {
+          "comment": "for expression (object)",
+          "name": "keyword.control.hcl"
+        }
+      },
+      "end": "\\}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.braces.end.hcl"
+        }
+      },
+      "patterns": [
+        {
+          "match": "\\=\\>",
+          "name": "storage.type.function.hcl"
+        },
+        {
+          "include": "#for_expression_body"
+        }
+      ]
+    },
+    "inline_for_expression": {
+      "begin": "(for)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.hcl"
+        }
+      },
+      "end": "\\n",
+      "patterns": [
+        {
+          "match": "\\=\\>",
+          "name": "storage.type.function.hcl"
+        },
+        {
+          "include": "#for_expression_body"
+        }
+      ]
+    },
+    "inline_if_expression": {
+      "begin": "(if)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.conditional.hcl"
+        }
+      },
+      "end": "\\n",
+      "patterns": [
+        {
+          "include": "#expressions"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#comma"
+        },
+        {
+          "include": "#local_identifiers"
+        }
+      ]
+    },
+    "for_expression_body": {
+      "patterns": [
+        {
+          "match": "\\bin\\b",
+          "comment": "in keyword",
+          "name": "keyword.operator.word.hcl"
+        },
+        {
+          "match": "\\bif\\b",
+          "comment": "if keyword",
+          "name": "keyword.control.conditional.hcl"
+        },
+        {
+          "match": "\\:",
+          "name": "keyword.operator.hcl"
+        },
+        {
+          "include": "#expressions"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#comma"
+        },
+        {
+          "include": "#local_identifiers"
+        }
+      ]
+    },
+    "attribute_access": {
+      "begin": "\\.",
+      "beginCaptures": {
+        "0": {
+          "name": "keyword.operator.accessor.hcl"
+        }
+      },
+      "end": "[[:alpha:]][[:alnum:]_-]*(\\[[0-9\\*]+\\])?",
+      "comment": "Matches a variable with an optional splat or index ([*]/[0])",
+      "endCaptures": {
+        "0": {
+          "patterns": [
+            {
+              "match": "\\b(?!null|false|true)[[:alpha:]][[:alnum:]_-]*\\b",
+              "comment": "Attribute name including - and _",
+              "name": "variable.other.member.hcl"
+            },
+            {
+              "match": "\\d+",
+              "comment": "Optional attribute index",
+              "name": "constant.numeric.integer.hcl"
+            },
+            {
+              "match": "\\*",
+              "comment": "Optional attribute-only splat",
+              "name": "keyword.operator.splat.hcl"
+            }
+          ]
+        }
+      }
+    },
+    "structural_types": {
+      "patterns": [
+        {
+          "begin": "(object)(\\()(\\{)\\s*",
+          "name": "meta.function-call.hcl",
+          "comment": "Object structural type",
+          "beginCaptures": {
+            "1": {
+              "name": "support.function.builtin.hcl"
+            },
+            "2": {
+              "name": "punctuation.section.parens.begin.hcl"
+            },
+            "3": {
+              "name": "punctuation.section.braces.begin.hcl"
+            }
+          },
+          "end": "(\\})(\\))",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.section.braces.end.hcl"
+            },
+            "2": {
+              "name": "punctuation.section.parens.end.hcl"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#comma"
+            },
+            {
+              "match": "((?!null|false|true)[[:alpha:]][[:alnum:]_-]*)\\s*(\\=(?!\\=|\\>))\\s*",
+              "comment": "Identifier \"=\"",
+              "name": "variable.declaration.hcl",
+              "captures": {
+                "1": {
+                  "name": "variable.other.readwrite.hcl"
+                },
+                "2": {
+                  "name": "keyword.operator.assignment.hcl"
+                }
+              }
+            },
+            {
+              "include": "#hcl_type_keywords"
+            }
+          ]
+        },
+        {
+          "begin": "(tuple)(\\()(\\[)\\s*",
+          "name": "meta.function-call.hcl",
+          "comment": "Tuple structural type",
+          "beginCaptures": {
+            "1": {
+              "name": "support.function.builtin.hcl"
+            },
+            "2": {
+              "name": "punctuation.section.parens.begin.hcl"
+            },
+            "3": {
+              "name": "punctuation.section.brackets.begin.hcl"
+            }
+          },
+          "end": "(\\])(\\))",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.section.brackets.end.hcl"
+            },
+            "2": {
+              "name": "punctuation.section.parens.end.hcl"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#comma"
+            },
+            {
+              "include": "#hcl_type_keywords"
+            }
+          ]
         }
       ]
     },
@@ -81,10 +801,6 @@
             {
               "match": "abspath|abs|ceil|floor|log|max|min|pow|signum|chomp|formatlist|indent|join|lower|regexall|regex|replace|split|strrev|substr|title|trimspace|upper|chunklist|coalescelist|coalesce|compact|concat|contains|distinct|element|flatten|index|keys|length|lookup|matchkeys|merge|range|reverse|setintersection|setproduct|setunion|slice|sort|transpose|values|zipmap|base64decode|base64encode|base64gzip|csvdecode|jsondecode|jsonencode|urlencode|yamldecode|yamlencode|dirname|pathexpand|basename|fileexists|fileset|filebase64|templatefile|formatdate|timeadd|timestamp|base64sha256|base64sha512|bcrypt|filebase64sha256|filebase64sha512|filemd5|filemd1|filesha256|filesha512|md5|rsadecrypt|sha1|sha256|sha512|uuidv5|uuid|cidrhost|cidrnetmask|cidrsubnet|tobool|tolist|tomap|tonumber|toset|tostring|file|format|map|list",
               "name": "support.function.builtin.terraform"
-            },
-            {
-              "match": "\\b(?!null|false|true)[[:alpha:]][[:alnum:]_-]*\\b",
-              "name": "variable.function.hcl"
             }
           ]
         },
@@ -99,9 +815,38 @@
         }
       },
       "patterns": [
-        { "include": "source.hcl#comments" },
-        { "include": "source.hcl#expressions" },
-        { "include": "source.hcl#comma" }
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#expressions"
+        },
+        {
+          "include": "#comma"
+        }
+      ]
+    },
+    "parens": {
+      "begin": "\\(",
+      "comment": "Parens - matched *after* function syntax",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.parens.begin.hcl"
+        }
+      },
+      "end": "\\)",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.parens.end.hcl"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#expressions"
+        },
+        {
+          "include": "#local_identifiers"
+        }
       ]
     }
   }

--- a/tests/snapshot/terraform/expressions_dynamic.tf.snap
+++ b/tests/snapshot/terraform/expressions_dynamic.tf.snap
@@ -29,7 +29,7 @@
 #            ^ source.hcl.terraform meta.block.hcl meta.block.hcl variable.declaration.hcl
 #             ^ source.hcl.terraform meta.block.hcl meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
 #              ^ source.hcl.terraform meta.block.hcl meta.block.hcl variable.declaration.hcl
-#               ^^^ source.hcl.terraform meta.block.hcl meta.block.hcl
+#               ^^^ source.hcl.terraform meta.block.hcl meta.block.hcl support.constant.terraform
 #                  ^ source.hcl.terraform meta.block.hcl meta.block.hcl keyword.operator.accessor.hcl
 #                   ^^^^^^^^ source.hcl.terraform meta.block.hcl meta.block.hcl variable.other.member.hcl
 >    content {
@@ -99,7 +99,7 @@
 #            ^ source.hcl.terraform meta.block.hcl meta.block.hcl variable.declaration.hcl
 #             ^ source.hcl.terraform meta.block.hcl meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
 #              ^ source.hcl.terraform meta.block.hcl meta.block.hcl variable.declaration.hcl
-#               ^^^ source.hcl.terraform meta.block.hcl meta.block.hcl
+#               ^^^ source.hcl.terraform meta.block.hcl meta.block.hcl support.constant.terraform
 #                  ^ source.hcl.terraform meta.block.hcl meta.block.hcl keyword.operator.accessor.hcl
 #                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl.terraform meta.block.hcl meta.block.hcl variable.other.member.hcl
 >    content {

--- a/tests/snapshot/terraform/expressions_for.tf.snap
+++ b/tests/snapshot/terraform/expressions_for.tf.snap
@@ -6,13 +6,13 @@
 #      ^ source.hcl.terraform
 #       ^^ source.hcl.terraform keyword.operator.word.hcl
 #         ^ source.hcl.terraform
-#          ^^^ source.hcl.terraform variable.other.readwrite.hcl
+#          ^^^ source.hcl.terraform support.constant.terraform
 #             ^ source.hcl.terraform keyword.operator.accessor.hcl
 #              ^^^^ source.hcl.terraform variable.other.member.hcl
 #                  ^ source.hcl.terraform
 #                   ^ source.hcl.terraform keyword.operator.hcl
 #                    ^ source.hcl.terraform
-#                     ^^^^^ source.hcl.terraform meta.function-call.hcl variable.function.hcl
+#                     ^^^^^ source.hcl.terraform meta.function-call.hcl support.function.builtin.terraform
 #                          ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.begin.hcl
 #                           ^ source.hcl.terraform meta.function-call.hcl
 #                            ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.end.hcl
@@ -29,20 +29,20 @@
 #         ^ source.hcl.terraform
 #          ^^ source.hcl.terraform keyword.operator.word.hcl
 #            ^ source.hcl.terraform
-#             ^^^ source.hcl.terraform variable.other.readwrite.hcl
+#             ^^^ source.hcl.terraform support.constant.terraform
 #                ^ source.hcl.terraform keyword.operator.accessor.hcl
 #                 ^^^ source.hcl.terraform variable.other.member.hcl
 #                    ^ source.hcl.terraform
 #                     ^ source.hcl.terraform keyword.operator.hcl
 #                      ^ source.hcl.terraform
-#                       ^^^^^^ source.hcl.terraform meta.function-call.hcl variable.function.hcl
+#                       ^^^^^^ source.hcl.terraform meta.function-call.hcl support.function.builtin.terraform
 #                             ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.begin.hcl
 #                              ^ source.hcl.terraform meta.function-call.hcl
 #                               ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.end.hcl
 #                                ^ source.hcl.terraform
 #                                 ^ source.hcl.terraform keyword.operator.arithmetic.hcl
 #                                  ^ source.hcl.terraform
-#                                   ^^^^^^ source.hcl.terraform meta.function-call.hcl variable.function.hcl
+#                                   ^^^^^^ source.hcl.terraform meta.function-call.hcl support.function.builtin.terraform
 #                                         ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.begin.hcl
 #                                          ^ source.hcl.terraform meta.function-call.hcl
 #                                           ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.end.hcl
@@ -59,7 +59,7 @@
 #         ^ source.hcl.terraform
 #          ^^ source.hcl.terraform keyword.operator.word.hcl
 #            ^ source.hcl.terraform
-#             ^^^ source.hcl.terraform variable.other.readwrite.hcl
+#             ^^^ source.hcl.terraform support.constant.terraform
 #                ^ source.hcl.terraform keyword.operator.accessor.hcl
 #                 ^^^^ source.hcl.terraform variable.other.member.hcl
 #                     ^ source.hcl.terraform
@@ -85,7 +85,7 @@
 #      ^ source.hcl.terraform
 #       ^^ source.hcl.terraform keyword.operator.word.hcl
 #         ^ source.hcl.terraform
-#          ^^^ source.hcl.terraform variable.other.readwrite.hcl
+#          ^^^ source.hcl.terraform support.constant.terraform
 #             ^ source.hcl.terraform keyword.operator.accessor.hcl
 #              ^^^^ source.hcl.terraform variable.other.member.hcl
 #                  ^ source.hcl.terraform
@@ -95,7 +95,7 @@
 #                      ^ source.hcl.terraform
 #                       ^^ source.hcl.terraform storage.type.function.hcl
 #                         ^ source.hcl.terraform
-#                          ^^^^^ source.hcl.terraform meta.function-call.hcl variable.function.hcl
+#                          ^^^^^ source.hcl.terraform meta.function-call.hcl support.function.builtin.terraform
 #                               ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.begin.hcl
 #                                ^ source.hcl.terraform meta.function-call.hcl
 #                                 ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.end.hcl
@@ -109,13 +109,13 @@
 #      ^ source.hcl.terraform
 #       ^^ source.hcl.terraform keyword.operator.word.hcl
 #         ^ source.hcl.terraform
-#          ^^^ source.hcl.terraform variable.other.readwrite.hcl
+#          ^^^ source.hcl.terraform support.constant.terraform
 #             ^ source.hcl.terraform keyword.operator.accessor.hcl
 #              ^^^^ source.hcl.terraform variable.other.member.hcl
 #                  ^ source.hcl.terraform
 #                   ^ source.hcl.terraform keyword.operator.hcl
 #                    ^ source.hcl.terraform
-#                     ^^^^^ source.hcl.terraform meta.function-call.hcl variable.function.hcl
+#                     ^^^^^ source.hcl.terraform meta.function-call.hcl support.function.builtin.terraform
 #                          ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.begin.hcl
 #                           ^ source.hcl.terraform meta.function-call.hcl
 #                            ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.end.hcl
@@ -152,7 +152,7 @@
 #                  ^ source.hcl.terraform meta.block.hcl meta.braces.hcl
 #                   ^^ source.hcl.terraform meta.block.hcl meta.braces.hcl keyword.operator.word.hcl
 #                     ^ source.hcl.terraform meta.block.hcl meta.braces.hcl
-#                      ^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl variable.other.readwrite.hcl
+#                      ^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl support.constant.terraform
 #                         ^ source.hcl.terraform meta.block.hcl meta.braces.hcl keyword.operator.accessor.hcl
 #                          ^^^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl variable.other.member.hcl
 #                               ^ source.hcl.terraform meta.block.hcl meta.braces.hcl
@@ -190,7 +190,7 @@
 #                  ^ source.hcl.terraform meta.block.hcl meta.braces.hcl
 #                   ^^ source.hcl.terraform meta.block.hcl meta.braces.hcl keyword.operator.word.hcl
 #                     ^ source.hcl.terraform meta.block.hcl meta.braces.hcl
-#                      ^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl variable.other.readwrite.hcl
+#                      ^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl support.constant.terraform
 #                         ^ source.hcl.terraform meta.block.hcl meta.braces.hcl keyword.operator.accessor.hcl
 #                          ^^^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl variable.other.member.hcl
 #                               ^ source.hcl.terraform meta.block.hcl meta.braces.hcl
@@ -230,7 +230,7 @@
 #                  ^ source.hcl.terraform meta.block.hcl
 #                   ^^ source.hcl.terraform meta.block.hcl keyword.operator.word.hcl
 #                     ^ source.hcl.terraform meta.block.hcl
-#                      ^^^ source.hcl.terraform meta.block.hcl variable.other.readwrite.hcl
+#                      ^^^ source.hcl.terraform meta.block.hcl support.constant.terraform
 #                         ^ source.hcl.terraform meta.block.hcl keyword.operator.accessor.hcl
 #                          ^^^^^ source.hcl.terraform meta.block.hcl variable.other.member.hcl
 #                               ^ source.hcl.terraform meta.block.hcl
@@ -264,7 +264,7 @@
 #                  ^ source.hcl.terraform meta.block.hcl
 #                   ^^ source.hcl.terraform meta.block.hcl keyword.operator.word.hcl
 #                     ^ source.hcl.terraform meta.block.hcl
-#                      ^^^ source.hcl.terraform meta.block.hcl variable.other.readwrite.hcl
+#                      ^^^ source.hcl.terraform meta.block.hcl support.constant.terraform
 #                         ^ source.hcl.terraform meta.block.hcl keyword.operator.accessor.hcl
 #                          ^^^^^ source.hcl.terraform meta.block.hcl variable.other.member.hcl
 #                               ^ source.hcl.terraform meta.block.hcl
@@ -307,7 +307,7 @@
 #                  ^ source.hcl.terraform meta.block.hcl meta.braces.hcl
 #                   ^^ source.hcl.terraform meta.block.hcl meta.braces.hcl keyword.operator.word.hcl
 #                     ^ source.hcl.terraform meta.block.hcl meta.braces.hcl
-#                      ^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl variable.other.readwrite.hcl
+#                      ^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl support.constant.terraform
 #                         ^ source.hcl.terraform meta.block.hcl meta.braces.hcl keyword.operator.accessor.hcl
 #                          ^^^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl variable.other.member.hcl
 #                               ^ source.hcl.terraform meta.block.hcl meta.braces.hcl

--- a/tests/snapshot/terraform/expressions_functions.tf.snap
+++ b/tests/snapshot/terraform/expressions_functions.tf.snap
@@ -48,7 +48,7 @@
 #            ^ source.hcl.terraform meta.function-call.hcl constant.numeric.integer.hcl
 #             ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.end.hcl
 >parseint("100", 10)
-#^^^^^^^^ source.hcl.terraform meta.function-call.hcl variable.function.hcl
+#^^^^^^^^ source.hcl.terraform meta.function-call.hcl
 #        ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.begin.hcl
 #         ^ source.hcl.terraform meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
 #          ^^^ source.hcl.terraform meta.function-call.hcl string.quoted.double.hcl
@@ -164,7 +164,7 @@
 # ^^^^^^^^ source.hcl.terraform string.quoted.double.hcl
 #         ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl
 #          ^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
-#            ^^^^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl meta.function-call.hcl variable.function.hcl
+#            ^^^^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl meta.function-call.hcl support.function.builtin.terraform
 #                  ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #                   ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl meta.function-call.hcl constant.numeric.integer.hcl
 #                    ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl meta.function-call.hcl punctuation.separator.hcl
@@ -294,7 +294,7 @@
 #                  ^ source.hcl.terraform meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
 #                   ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.end.hcl
 >trim("?!hello?!", "!?")
-#^^^^ source.hcl.terraform meta.function-call.hcl variable.function.hcl
+#^^^^ source.hcl.terraform meta.function-call.hcl
 #    ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.begin.hcl
 #     ^ source.hcl.terraform meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
 #      ^^^^^^^^^ source.hcl.terraform meta.function-call.hcl string.quoted.double.hcl
@@ -306,7 +306,7 @@
 #                     ^ source.hcl.terraform meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
 #                      ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.end.hcl
 >trimprefix("helloworld", "hello")
-#^^^^^^^^^^ source.hcl.terraform meta.function-call.hcl variable.function.hcl
+#^^^^^^^^^^ source.hcl.terraform meta.function-call.hcl
 #          ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.begin.hcl
 #           ^ source.hcl.terraform meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
 #            ^^^^^^^^^^ source.hcl.terraform meta.function-call.hcl string.quoted.double.hcl
@@ -318,7 +318,7 @@
 #                               ^ source.hcl.terraform meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
 #                                ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.end.hcl
 >trimsuffix("helloworld", "world")
-#^^^^^^^^^^ source.hcl.terraform meta.function-call.hcl variable.function.hcl
+#^^^^^^^^^^ source.hcl.terraform meta.function-call.hcl
 #          ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.begin.hcl
 #           ^ source.hcl.terraform meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
 #            ^^^^^^^^^^ source.hcl.terraform meta.function-call.hcl string.quoted.double.hcl
@@ -351,7 +351,7 @@
 # ^^^^^^ source.hcl.terraform comment.line.number-sign.hcl
 >
 >foo("bar")
-#^^^ source.hcl.terraform meta.function-call.hcl variable.function.hcl
+#^^^ source.hcl.terraform meta.function-call.hcl
 #   ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.begin.hcl
 #    ^ source.hcl.terraform meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
 #     ^^^ source.hcl.terraform meta.function-call.hcl string.quoted.double.hcl

--- a/tests/snapshot/terraform/expressions_splat.tf.snap
+++ b/tests/snapshot/terraform/expressions_splat.tf.snap
@@ -6,7 +6,7 @@
 #      ^ source.hcl.terraform
 #       ^^ source.hcl.terraform keyword.operator.word.hcl
 #         ^ source.hcl.terraform
-#          ^^^ source.hcl.terraform variable.other.readwrite.hcl
+#          ^^^ source.hcl.terraform support.constant.terraform
 #             ^ source.hcl.terraform keyword.operator.accessor.hcl
 #              ^^^^ source.hcl.terraform variable.other.member.hcl
 #                  ^ source.hcl.terraform

--- a/tests/snapshot/terraform/expressions_strings.tf.snap
+++ b/tests/snapshot/terraform/expressions_strings.tf.snap
@@ -83,7 +83,7 @@
 # ^^^^^^ source.hcl.terraform string.quoted.double.hcl
 #       ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl
 #        ^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
-#          ^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.readwrite.hcl
+#          ^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl support.constant.terraform
 #             ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
 #              ^^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
 #                  ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
@@ -98,7 +98,7 @@
 #          ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl
 #           ^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.control.hcl
 #             ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl
-#              ^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.readwrite.hcl
+#              ^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl support.constant.terraform
 #                 ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
 #                  ^^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
 #                      ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl

--- a/tests/snapshot/terraform/issue927.tf.snap
+++ b/tests/snapshot/terraform/issue927.tf.snap
@@ -16,7 +16,7 @@
 #                           ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl
 #                            ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
 #                             ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl
-#                              ^^^ source.hcl.terraform meta.block.hcl
+#                              ^^^ source.hcl.terraform meta.block.hcl support.constant.terraform
 #                                 ^ source.hcl.terraform meta.block.hcl keyword.operator.accessor.hcl
 #                                  ^^^ source.hcl.terraform meta.block.hcl variable.other.member.hcl
 #                                     ^ source.hcl.terraform meta.block.hcl
@@ -61,7 +61,7 @@
 #     ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl
 #      ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
 #       ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl
-#        ^^^ source.hcl.terraform meta.block.hcl
+#        ^^^ source.hcl.terraform meta.block.hcl support.constant.terraform
 #           ^ source.hcl.terraform meta.block.hcl keyword.operator.accessor.hcl
 #            ^^^^^^^^ source.hcl.terraform meta.block.hcl variable.other.member.hcl
 >}
@@ -88,7 +88,7 @@
 #     ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl
 #      ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
 #       ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl
-#        ^^^^^^ source.hcl.terraform meta.block.hcl
+#        ^^^^^^ source.hcl.terraform meta.block.hcl support.constant.terraform
 #              ^ source.hcl.terraform meta.block.hcl keyword.operator.accessor.hcl
 #               ^^^^^^^ source.hcl.terraform meta.block.hcl variable.other.member.hcl
 #                      ^ source.hcl.terraform meta.block.hcl keyword.operator.accessor.hcl

--- a/tests/snapshot/terraform/modules.tf.snap
+++ b/tests/snapshot/terraform/modules.tf.snap
@@ -43,7 +43,7 @@
 #           ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl
 #            ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
 #             ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl
-#              ^^^^^^ source.hcl.terraform meta.block.hcl
+#              ^^^^^^ source.hcl.terraform meta.block.hcl support.constant.terraform
 #                    ^ source.hcl.terraform meta.block.hcl keyword.operator.accessor.hcl
 #                     ^^^^^^^ source.hcl.terraform meta.block.hcl variable.other.member.hcl
 #                            ^ source.hcl.terraform meta.block.hcl keyword.operator.accessor.hcl

--- a/tests/snapshot/terraform/variables_input.tf.snap
+++ b/tests/snapshot/terraform/variables_input.tf.snap
@@ -30,7 +30,7 @@
 #      ^^^^ source.hcl.terraform meta.block.hcl variable.declaration.hcl
 #          ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
 #           ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl
-#            ^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl variable.function.hcl
+#            ^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl support.function.builtin.terraform
 #                ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #                 ^^^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl storage.type.hcl
 #                       ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
@@ -60,7 +60,7 @@
 #      ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl
 #       ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
 #        ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl
-#         ^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl variable.function.hcl
+#         ^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl support.function.builtin.terraform
 #             ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #              ^^^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl meta.function-call.hcl support.function.builtin.hcl
 #                    ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
@@ -167,9 +167,9 @@
 #             ^^^^^ source.hcl.terraform meta.block.hcl meta.block.hcl variable.declaration.hcl
 #                  ^ source.hcl.terraform meta.block.hcl meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
 #                   ^ source.hcl.terraform meta.block.hcl meta.block.hcl variable.declaration.hcl
-#                    ^^^^^^ source.hcl.terraform meta.block.hcl meta.block.hcl meta.function-call.hcl variable.function.hcl
+#                    ^^^^^^ source.hcl.terraform meta.block.hcl meta.block.hcl meta.function-call.hcl support.function.builtin.terraform
 #                          ^ source.hcl.terraform meta.block.hcl meta.block.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
-#                           ^^^ source.hcl.terraform meta.block.hcl meta.block.hcl meta.function-call.hcl
+#                           ^^^ source.hcl.terraform meta.block.hcl meta.block.hcl meta.function-call.hcl support.constant.terraform
 #                              ^ source.hcl.terraform meta.block.hcl meta.block.hcl meta.function-call.hcl keyword.operator.accessor.hcl
 #                               ^^^^^^^^ source.hcl.terraform meta.block.hcl meta.block.hcl meta.function-call.hcl variable.other.member.hcl
 #                                       ^ source.hcl.terraform meta.block.hcl meta.block.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
@@ -180,9 +180,9 @@
 #                                            ^ source.hcl.terraform meta.block.hcl meta.block.hcl
 #                                             ^^ source.hcl.terraform meta.block.hcl meta.block.hcl keyword.operator.logical.hcl
 #                                               ^ source.hcl.terraform meta.block.hcl meta.block.hcl
-#                                                ^^^^^^ source.hcl.terraform meta.block.hcl meta.block.hcl meta.function-call.hcl variable.function.hcl
+#                                                ^^^^^^ source.hcl.terraform meta.block.hcl meta.block.hcl meta.function-call.hcl support.function.builtin.terraform
 #                                                      ^ source.hcl.terraform meta.block.hcl meta.block.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
-#                                                       ^^^ source.hcl.terraform meta.block.hcl meta.block.hcl meta.function-call.hcl
+#                                                       ^^^ source.hcl.terraform meta.block.hcl meta.block.hcl meta.function-call.hcl support.constant.terraform
 #                                                          ^ source.hcl.terraform meta.block.hcl meta.block.hcl meta.function-call.hcl keyword.operator.accessor.hcl
 #                                                           ^^^^^^^^ source.hcl.terraform meta.block.hcl meta.block.hcl meta.function-call.hcl variable.other.member.hcl
 #                                                                   ^ source.hcl.terraform meta.block.hcl meta.block.hcl meta.function-call.hcl punctuation.separator.hcl

--- a/tests/snapshot/terraform/variables_local.tf.snap
+++ b/tests/snapshot/terraform/variables_local.tf.snap
@@ -37,7 +37,7 @@
 #              ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl
 #               ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
 #                ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl
-#                 ^^^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl variable.function.hcl
+#                 ^^^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl support.function.builtin.terraform
 #                       ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #                        ^^^^^^^^^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl
 #                                    ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl keyword.operator.accessor.hcl
@@ -77,14 +77,16 @@
 #           ^ source.hcl.terraform meta.block.hcl meta.braces.hcl
 #            ^ source.hcl.terraform meta.block.hcl meta.braces.hcl keyword.operator.assignment.hcl
 #             ^ source.hcl.terraform meta.block.hcl meta.braces.hcl
-#              ^^^^^^^^^^^^^^^^^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl
+#              ^^^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl support.constant.terraform
+#                   ^^^^^^^^^^^^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl
 >    Owner   = local.owner
 #^^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl
 #    ^^^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
 #         ^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl
 #            ^ source.hcl.terraform meta.block.hcl meta.braces.hcl keyword.operator.assignment.hcl
 #             ^ source.hcl.terraform meta.block.hcl meta.braces.hcl
-#              ^^^^^^^^^^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl
+#              ^^^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl support.constant.terraform
+#                   ^^^^^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl
 >  }
 #^^ source.hcl.terraform meta.block.hcl meta.braces.hcl
 #  ^ source.hcl.terraform meta.block.hcl meta.braces.hcl punctuation.section.braces.end.hcl
@@ -110,7 +112,7 @@
 #      ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl
 #       ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
 #        ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl
-#         ^^^^^ source.hcl.terraform meta.block.hcl
+#         ^^^^^ source.hcl.terraform meta.block.hcl support.constant.terraform
 #              ^ source.hcl.terraform meta.block.hcl keyword.operator.accessor.hcl
 #               ^^^^^^^^^^^ source.hcl.terraform meta.block.hcl variable.other.member.hcl
 >}


### PR DESCRIPTION
This PR removes all cross-file include patterns from the Terraform grammar by duplicating the patterns from the HCL grammar. 

In an editor of your choice, one can view the Terraform-specific changes best by comparing `terraform.tmGrammar.json` and `hcl.tmGrammar.json`.

## Before

![CleanShot 2022-03-15 at 20 17 16](https://user-images.githubusercontent.com/45985/158454420-4da1cf40-b106-4124-8ebc-e12f5d5bbba2.png)
![CleanShot 2022-03-15 at 20 17 07](https://user-images.githubusercontent.com/45985/158454428-b7e340cf-f638-415f-9728-8825074686f4.png)

## After

![CleanShot 2022-03-15 at 20 16 38](https://user-images.githubusercontent.com/45985/158454438-bc717474-d0f1-450c-8d16-06fb3f51038a.png)
![CleanShot 2022-03-15 at 20 15 23](https://user-images.githubusercontent.com/45985/158454453-29c826e4-d83c-4b28-9edf-10549f4de0fd.png)


Closes #16 