### PR TITLE
Update scope for HCL function highlighting

### DIFF
--- a/syntaxes/hcl.tmGrammar.json
+++ b/syntaxes/hcl.tmGrammar.json
@@ -777,7 +777,7 @@
           "patterns": [
             {
               "match": "\\b(?!null|false|true)[[:alpha:]][[:alnum:]_-]*\\b",
-              "name": "variable.function.hcl"
+              "name": "support.function.builtin.hcl"
             }
           ]
         },

--- a/tests/snapshot/hcl/basic.hcl.snap
+++ b/tests/snapshot/hcl/basic.hcl.snap
@@ -125,7 +125,7 @@
 #              ^ source.hcl variable.declaration.hcl
 #               ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
 #                ^ source.hcl variable.declaration.hcl
-#                 ^^^^^ source.hcl meta.function-call.hcl variable.function.hcl
+#                 ^^^^^ source.hcl meta.function-call.hcl support.function.builtin.hcl
 #                      ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #                       ^^^^^^^ source.hcl meta.function-call.hcl
 #                              ^ source.hcl meta.function-call.hcl punctuation.section.parens.end.hcl

--- a/tests/snapshot/hcl/expressions_conditional.hcl.snap
+++ b/tests/snapshot/hcl/expressions_conditional.hcl.snap
@@ -25,7 +25,7 @@
 #           ^ source.hcl
 #            ^ source.hcl keyword.operator.hcl
 #             ^ source.hcl
-#              ^^^^^^^^ source.hcl meta.function-call.hcl variable.function.hcl
+#              ^^^^^^^^ source.hcl meta.function-call.hcl support.function.builtin.hcl
 #                      ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #                       ^^ source.hcl meta.function-call.hcl constant.numeric.integer.hcl
 #                         ^ source.hcl meta.function-call.hcl punctuation.section.parens.end.hcl

--- a/tests/snapshot/hcl/expressions_for.hcl.snap
+++ b/tests/snapshot/hcl/expressions_for.hcl.snap
@@ -12,7 +12,7 @@
 #                  ^ source.hcl
 #                   ^ source.hcl keyword.operator.hcl
 #                    ^ source.hcl
-#                     ^^^^^ source.hcl meta.function-call.hcl variable.function.hcl
+#                     ^^^^^ source.hcl meta.function-call.hcl support.function.builtin.hcl
 #                          ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #                           ^ source.hcl meta.function-call.hcl
 #                            ^ source.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
@@ -35,14 +35,14 @@
 #                    ^ source.hcl
 #                     ^ source.hcl keyword.operator.hcl
 #                      ^ source.hcl
-#                       ^^^^^^ source.hcl meta.function-call.hcl variable.function.hcl
+#                       ^^^^^^ source.hcl meta.function-call.hcl support.function.builtin.hcl
 #                             ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #                              ^ source.hcl meta.function-call.hcl
 #                               ^ source.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
 #                                ^ source.hcl
 #                                 ^ source.hcl keyword.operator.arithmetic.hcl
 #                                  ^ source.hcl
-#                                   ^^^^^^ source.hcl meta.function-call.hcl variable.function.hcl
+#                                   ^^^^^^ source.hcl meta.function-call.hcl support.function.builtin.hcl
 #                                         ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #                                          ^ source.hcl meta.function-call.hcl
 #                                           ^ source.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
@@ -95,7 +95,7 @@
 #                      ^ source.hcl
 #                       ^^ source.hcl storage.type.function.hcl
 #                         ^ source.hcl
-#                          ^^^^^ source.hcl meta.function-call.hcl variable.function.hcl
+#                          ^^^^^ source.hcl meta.function-call.hcl support.function.builtin.hcl
 #                               ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #                                ^ source.hcl meta.function-call.hcl
 #                                 ^ source.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
@@ -115,7 +115,7 @@
 #                  ^ source.hcl
 #                   ^ source.hcl keyword.operator.hcl
 #                    ^ source.hcl
-#                     ^^^^^ source.hcl meta.function-call.hcl variable.function.hcl
+#                     ^^^^^ source.hcl meta.function-call.hcl support.function.builtin.hcl
 #                          ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #                           ^ source.hcl meta.function-call.hcl
 #                            ^ source.hcl meta.function-call.hcl punctuation.section.parens.end.hcl

--- a/tests/snapshot/hcl/expressions_functions.hcl.snap
+++ b/tests/snapshot/hcl/expressions_functions.hcl.snap
@@ -3,22 +3,22 @@
 # ^^^^^^^^ source.hcl comment.line.number-sign.hcl
 >
 >abs(23)
-#^^^ source.hcl meta.function-call.hcl variable.function.hcl
+#^^^ source.hcl meta.function-call.hcl support.function.builtin.hcl
 #   ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #    ^^ source.hcl meta.function-call.hcl constant.numeric.integer.hcl
 #      ^ source.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
 >ceil(5)
-#^^^^ source.hcl meta.function-call.hcl variable.function.hcl
+#^^^^ source.hcl meta.function-call.hcl support.function.builtin.hcl
 #    ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #     ^ source.hcl meta.function-call.hcl constant.numeric.integer.hcl
 #      ^ source.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
 >floor(5)
-#^^^^^ source.hcl meta.function-call.hcl variable.function.hcl
+#^^^^^ source.hcl meta.function-call.hcl support.function.builtin.hcl
 #     ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #      ^ source.hcl meta.function-call.hcl constant.numeric.integer.hcl
 #       ^ source.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
 >log(50, 10)
-#^^^ source.hcl meta.function-call.hcl variable.function.hcl
+#^^^ source.hcl meta.function-call.hcl support.function.builtin.hcl
 #   ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #    ^^ source.hcl meta.function-call.hcl constant.numeric.integer.hcl
 #      ^ source.hcl meta.function-call.hcl punctuation.separator.hcl
@@ -26,7 +26,7 @@
 #        ^^ source.hcl meta.function-call.hcl constant.numeric.integer.hcl
 #          ^ source.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
 >max(12, 54, 3)
-#^^^ source.hcl meta.function-call.hcl variable.function.hcl
+#^^^ source.hcl meta.function-call.hcl support.function.builtin.hcl
 #   ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #    ^^ source.hcl meta.function-call.hcl constant.numeric.integer.hcl
 #      ^ source.hcl meta.function-call.hcl punctuation.separator.hcl
@@ -37,7 +37,7 @@
 #            ^ source.hcl meta.function-call.hcl constant.numeric.integer.hcl
 #             ^ source.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
 >min(12, 54, 3)
-#^^^ source.hcl meta.function-call.hcl variable.function.hcl
+#^^^ source.hcl meta.function-call.hcl support.function.builtin.hcl
 #   ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #    ^^ source.hcl meta.function-call.hcl constant.numeric.integer.hcl
 #      ^ source.hcl meta.function-call.hcl punctuation.separator.hcl
@@ -48,7 +48,7 @@
 #            ^ source.hcl meta.function-call.hcl constant.numeric.integer.hcl
 #             ^ source.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
 >parseint("100", 10)
-#^^^^^^^^ source.hcl meta.function-call.hcl variable.function.hcl
+#^^^^^^^^ source.hcl meta.function-call.hcl support.function.builtin.hcl
 #        ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #         ^ source.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
 #          ^^^ source.hcl meta.function-call.hcl string.quoted.double.hcl
@@ -58,7 +58,7 @@
 #                ^^ source.hcl meta.function-call.hcl constant.numeric.integer.hcl
 #                  ^ source.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
 >pow(3, 2)
-#^^^ source.hcl meta.function-call.hcl variable.function.hcl
+#^^^ source.hcl meta.function-call.hcl support.function.builtin.hcl
 #   ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #    ^ source.hcl meta.function-call.hcl constant.numeric.integer.hcl
 #     ^ source.hcl meta.function-call.hcl punctuation.separator.hcl
@@ -66,7 +66,7 @@
 #       ^ source.hcl meta.function-call.hcl constant.numeric.integer.hcl
 #        ^ source.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
 >signum(-13)
-#^^^^^^ source.hcl meta.function-call.hcl variable.function.hcl
+#^^^^^^ source.hcl meta.function-call.hcl support.function.builtin.hcl
 #      ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #       ^ source.hcl meta.function-call.hcl keyword.operator.arithmetic.hcl
 #        ^^ source.hcl meta.function-call.hcl constant.numeric.integer.hcl
@@ -77,7 +77,7 @@
 # ^^^^^^^ source.hcl comment.line.number-sign.hcl
 >
 >chomp("hello\n")
-#^^^^^ source.hcl meta.function-call.hcl variable.function.hcl
+#^^^^^ source.hcl meta.function-call.hcl support.function.builtin.hcl
 #     ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #      ^ source.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
 #       ^^^^^ source.hcl meta.function-call.hcl string.quoted.double.hcl
@@ -85,7 +85,7 @@
 #              ^ source.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
 #               ^ source.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
 >format("Hello, %s!", "Ander")
-#^^^^^^ source.hcl meta.function-call.hcl variable.function.hcl
+#^^^^^^ source.hcl meta.function-call.hcl support.function.builtin.hcl
 #      ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #       ^ source.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
 #        ^^^^^^^^^^ source.hcl meta.function-call.hcl string.quoted.double.hcl
@@ -97,7 +97,7 @@
 #                           ^ source.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
 #                            ^ source.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
 >formatlist("Hello, %s!", ["Valentina", "Ander", "Olivia", "Sam"])
-#^^^^^^^^^^ source.hcl meta.function-call.hcl variable.function.hcl
+#^^^^^^^^^^ source.hcl meta.function-call.hcl support.function.builtin.hcl
 #          ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #           ^ source.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
 #            ^^^^^^^^^^ source.hcl meta.function-call.hcl string.quoted.double.hcl
@@ -126,7 +126,7 @@
 #                                                               ^ source.hcl meta.function-call.hcl punctuation.section.brackets.end.hcl
 #                                                                ^ source.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
 >formatlist("%s, %s!", "Salutations", ["Valentina", "Ander", "Olivia", "Sam"])
-#^^^^^^^^^^ source.hcl meta.function-call.hcl variable.function.hcl
+#^^^^^^^^^^ source.hcl meta.function-call.hcl support.function.builtin.hcl
 #          ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #           ^ source.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
 #            ^^^^^^^ source.hcl meta.function-call.hcl string.quoted.double.hcl
@@ -164,7 +164,7 @@
 # ^^^^^^^^ source.hcl string.quoted.double.hcl
 #         ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl
 #          ^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
-#            ^^^^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl meta.function-call.hcl variable.function.hcl
+#            ^^^^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl meta.function-call.hcl support.function.builtin.hcl
 #                  ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #                   ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl meta.function-call.hcl constant.numeric.integer.hcl
 #                    ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl meta.function-call.hcl punctuation.separator.hcl
@@ -183,7 +183,7 @@
 #                                               ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
 #                                                ^ source.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
 >join(", ", ["foo", "bar", "baz"])
-#^^^^ source.hcl meta.function-call.hcl variable.function.hcl
+#^^^^ source.hcl meta.function-call.hcl support.function.builtin.hcl
 #    ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #     ^ source.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
 #      ^^ source.hcl meta.function-call.hcl string.quoted.double.hcl
@@ -207,14 +207,14 @@
 #                               ^ source.hcl meta.function-call.hcl punctuation.section.brackets.end.hcl
 #                                ^ source.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
 >lower("HELLO")
-#^^^^^ source.hcl meta.function-call.hcl variable.function.hcl
+#^^^^^ source.hcl meta.function-call.hcl support.function.builtin.hcl
 #     ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #      ^ source.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
 #       ^^^^^ source.hcl meta.function-call.hcl string.quoted.double.hcl
 #            ^ source.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
 #             ^ source.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
 >regex("[a-z]+", "53453453.345345aaabbbccc23454")
-#^^^^^ source.hcl meta.function-call.hcl variable.function.hcl
+#^^^^^ source.hcl meta.function-call.hcl support.function.builtin.hcl
 #     ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #      ^ source.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
 #       ^^^^^^ source.hcl meta.function-call.hcl string.quoted.double.hcl
@@ -226,7 +226,7 @@
 #                                              ^ source.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
 #                                               ^ source.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
 >regexall("[a-z]+", "1234abcd5678efgh9")
-#^^^^^^^^ source.hcl meta.function-call.hcl variable.function.hcl
+#^^^^^^^^ source.hcl meta.function-call.hcl support.function.builtin.hcl
 #        ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #         ^ source.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
 #          ^^^^^^ source.hcl meta.function-call.hcl string.quoted.double.hcl
@@ -238,7 +238,7 @@
 #                                     ^ source.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
 #                                      ^ source.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
 >replace("1 + 2 + 3", "+", "-")
-#^^^^^^^ source.hcl meta.function-call.hcl variable.function.hcl
+#^^^^^^^ source.hcl meta.function-call.hcl support.function.builtin.hcl
 #       ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #        ^ source.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
 #         ^^^^^^^^^ source.hcl meta.function-call.hcl string.quoted.double.hcl
@@ -255,7 +255,7 @@
 #                            ^ source.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
 #                             ^ source.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
 >split(",", "foo,bar,baz")
-#^^^^^ source.hcl meta.function-call.hcl variable.function.hcl
+#^^^^^ source.hcl meta.function-call.hcl support.function.builtin.hcl
 #     ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #      ^ source.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
 #       ^ source.hcl meta.function-call.hcl string.quoted.double.hcl
@@ -267,14 +267,14 @@
 #                       ^ source.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
 #                        ^ source.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
 >strrev("hello")
-#^^^^^^ source.hcl meta.function-call.hcl variable.function.hcl
+#^^^^^^ source.hcl meta.function-call.hcl support.function.builtin.hcl
 #      ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #       ^ source.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
 #        ^^^^^ source.hcl meta.function-call.hcl string.quoted.double.hcl
 #             ^ source.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
 #              ^ source.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
 >substr("hello world", 1, 4)
-#^^^^^^ source.hcl meta.function-call.hcl variable.function.hcl
+#^^^^^^ source.hcl meta.function-call.hcl support.function.builtin.hcl
 #      ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #       ^ source.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
 #        ^^^^^^^^^^^ source.hcl meta.function-call.hcl string.quoted.double.hcl
@@ -287,14 +287,14 @@
 #                         ^ source.hcl meta.function-call.hcl constant.numeric.integer.hcl
 #                          ^ source.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
 >title("hello world")
-#^^^^^ source.hcl meta.function-call.hcl variable.function.hcl
+#^^^^^ source.hcl meta.function-call.hcl support.function.builtin.hcl
 #     ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #      ^ source.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
 #       ^^^^^^^^^^^ source.hcl meta.function-call.hcl string.quoted.double.hcl
 #                  ^ source.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
 #                   ^ source.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
 >trim("?!hello?!", "!?")
-#^^^^ source.hcl meta.function-call.hcl variable.function.hcl
+#^^^^ source.hcl meta.function-call.hcl support.function.builtin.hcl
 #    ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #     ^ source.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
 #      ^^^^^^^^^ source.hcl meta.function-call.hcl string.quoted.double.hcl
@@ -306,7 +306,7 @@
 #                     ^ source.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
 #                      ^ source.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
 >trimprefix("helloworld", "hello")
-#^^^^^^^^^^ source.hcl meta.function-call.hcl variable.function.hcl
+#^^^^^^^^^^ source.hcl meta.function-call.hcl support.function.builtin.hcl
 #          ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #           ^ source.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
 #            ^^^^^^^^^^ source.hcl meta.function-call.hcl string.quoted.double.hcl
@@ -318,7 +318,7 @@
 #                               ^ source.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
 #                                ^ source.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
 >trimsuffix("helloworld", "world")
-#^^^^^^^^^^ source.hcl meta.function-call.hcl variable.function.hcl
+#^^^^^^^^^^ source.hcl meta.function-call.hcl support.function.builtin.hcl
 #          ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #           ^ source.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
 #            ^^^^^^^^^^ source.hcl meta.function-call.hcl string.quoted.double.hcl
@@ -330,7 +330,7 @@
 #                               ^ source.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
 #                                ^ source.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
 >trimspace("  hello\n\n")
-#^^^^^^^^^ source.hcl meta.function-call.hcl variable.function.hcl
+#^^^^^^^^^ source.hcl meta.function-call.hcl support.function.builtin.hcl
 #         ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #          ^ source.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
 #           ^^^^^^^ source.hcl meta.function-call.hcl string.quoted.double.hcl
@@ -339,7 +339,7 @@
 #                      ^ source.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
 #                       ^ source.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
 >upper("hello")
-#^^^^^ source.hcl meta.function-call.hcl variable.function.hcl
+#^^^^^ source.hcl meta.function-call.hcl support.function.builtin.hcl
 #     ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #      ^ source.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
 #       ^^^^^ source.hcl meta.function-call.hcl string.quoted.double.hcl
@@ -351,7 +351,7 @@
 # ^^^^^^ source.hcl comment.line.number-sign.hcl
 >
 >foo("bar")
-#^^^ source.hcl meta.function-call.hcl variable.function.hcl
+#^^^ source.hcl meta.function-call.hcl support.function.builtin.hcl
 #   ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #    ^ source.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
 #     ^^^ source.hcl meta.function-call.hcl string.quoted.double.hcl

--- a/tests/snapshot/hcl/issue941.hcl.snap
+++ b/tests/snapshot/hcl/issue941.hcl.snap
@@ -9,7 +9,7 @@
 #                                     ^^^^^^^ source.hcl comment.line.number-sign.hcl
 >  length(var.instance_size) > 0 ? ( #Comment
 #^^ source.hcl
-#  ^^^^^^ source.hcl meta.function-call.hcl variable.function.hcl
+#  ^^^^^^ source.hcl meta.function-call.hcl support.function.builtin.hcl
 #        ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #         ^^^ source.hcl meta.function-call.hcl
 #            ^ source.hcl meta.function-call.hcl keyword.operator.accessor.hcl
@@ -55,7 +55,7 @@
 #                   ^ source.hcl keyword.operator.hcl
 >    lookup(local.insane_mode_instance_size_map, local.cloud, null) #If instance size is not provided and var.insane_mode is true, lookup in this table.
 #^^^^ source.hcl
-#    ^^^^^^ source.hcl meta.function-call.hcl variable.function.hcl
+#    ^^^^^^ source.hcl meta.function-call.hcl support.function.builtin.hcl
 #          ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #           ^^^^^ source.hcl meta.function-call.hcl
 #                ^ source.hcl meta.function-call.hcl keyword.operator.accessor.hcl
@@ -78,7 +78,7 @@
 #                                                                   ^ source.hcl comment.line.number-sign.hcl punctuation.definition.comment.hcl
 >    lookup(local.instance_size_map, local.cloud, null)             #If instance size is not provided and var.insane_mode is false, lookup in this table.
 #^^^^ source.hcl
-#    ^^^^^^ source.hcl meta.function-call.hcl variable.function.hcl
+#    ^^^^^^ source.hcl meta.function-call.hcl support.function.builtin.hcl
 #          ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #           ^^^^^ source.hcl meta.function-call.hcl
 #                ^ source.hcl meta.function-call.hcl keyword.operator.accessor.hcl

--- a/tests/snapshot/hcl/variables_input.hcl.snap
+++ b/tests/snapshot/hcl/variables_input.hcl.snap
@@ -30,7 +30,7 @@
 #      ^^^^ source.hcl meta.block.hcl variable.declaration.hcl
 #          ^ source.hcl meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
 #           ^ source.hcl meta.block.hcl variable.declaration.hcl
-#            ^^^^ source.hcl meta.block.hcl meta.function-call.hcl variable.function.hcl
+#            ^^^^ source.hcl meta.block.hcl meta.function-call.hcl support.function.builtin.hcl
 #                ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #                 ^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl storage.type.hcl
 #                       ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
@@ -60,7 +60,7 @@
 #      ^ source.hcl meta.block.hcl variable.declaration.hcl
 #       ^ source.hcl meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
 #        ^ source.hcl meta.block.hcl variable.declaration.hcl
-#         ^^^^ source.hcl meta.block.hcl meta.function-call.hcl variable.function.hcl
+#         ^^^^ source.hcl meta.block.hcl meta.function-call.hcl support.function.builtin.hcl
 #             ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #              ^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl support.function.builtin.hcl
 #                    ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
@@ -167,7 +167,7 @@
 #             ^^^^^ source.hcl meta.block.hcl meta.block.hcl variable.declaration.hcl
 #                  ^ source.hcl meta.block.hcl meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
 #                   ^ source.hcl meta.block.hcl meta.block.hcl variable.declaration.hcl
-#                    ^^^^^^ source.hcl meta.block.hcl meta.block.hcl meta.function-call.hcl variable.function.hcl
+#                    ^^^^^^ source.hcl meta.block.hcl meta.block.hcl meta.function-call.hcl support.function.builtin.hcl
 #                          ^ source.hcl meta.block.hcl meta.block.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #                           ^^^ source.hcl meta.block.hcl meta.block.hcl meta.function-call.hcl
 #                              ^ source.hcl meta.block.hcl meta.block.hcl meta.function-call.hcl keyword.operator.accessor.hcl
@@ -180,7 +180,7 @@
 #                                            ^ source.hcl meta.block.hcl meta.block.hcl
 #                                             ^^ source.hcl meta.block.hcl meta.block.hcl keyword.operator.logical.hcl
 #                                               ^ source.hcl meta.block.hcl meta.block.hcl
-#                                                ^^^^^^ source.hcl meta.block.hcl meta.block.hcl meta.function-call.hcl variable.function.hcl
+#                                                ^^^^^^ source.hcl meta.block.hcl meta.block.hcl meta.function-call.hcl support.function.builtin.hcl
 #                                                      ^ source.hcl meta.block.hcl meta.block.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #                                                       ^^^ source.hcl meta.block.hcl meta.block.hcl meta.function-call.hcl
 #                                                          ^ source.hcl meta.block.hcl meta.block.hcl meta.function-call.hcl keyword.operator.accessor.hcl

--- a/tests/snapshot/hcl/variables_local.hcl.snap
+++ b/tests/snapshot/hcl/variables_local.hcl.snap
@@ -37,7 +37,7 @@
 #              ^ source.hcl meta.block.hcl variable.declaration.hcl
 #               ^ source.hcl meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
 #                ^ source.hcl meta.block.hcl variable.declaration.hcl
-#                 ^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl variable.function.hcl
+#                 ^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl support.function.builtin.hcl
 #                       ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
 #                        ^^^^^^^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl
 #                                    ^ source.hcl meta.block.hcl meta.function-call.hcl keyword.operator.accessor.hcl


### PR DESCRIPTION
This PR updates the scope for generic functions in HCL to be more in line with theme scopes.

## Before
![CleanShot 2022-03-15 at 20 19 20](https://user-images.githubusercontent.com/45985/158455496-1a87a073-26b1-4c86-8d7d-5ab905cbb8a3.png)

## After
![CleanShot 2022-03-15 at 20 21 17](https://user-images.githubusercontent.com/45985/158455504-3f59e12e-720a-453b-b3e0-39076c5860b5.png)

Should be merged after #17 (this will fix the Terraform snapshot tests)
