### PR TITLE
Fix highlighting of nested complex types

### DIFF
--- a/syntaxes/hcl.tmGrammar.json
+++ b/syntaxes/hcl.tmGrammar.json
@@ -31,7 +31,7 @@
       "name": "variable.other.readwrite.hcl"
     },
     "hcl_type_keywords": {
-      "match": "\\b(any|string|number|bool)\\b",
+      "match": "\\b(any|string|number|bool|list|set|map|tuple|object)\\b",
       "comment": "Type keywords known to HCL.",
       "name": "storage.type.hcl"
     },
@@ -156,9 +156,6 @@
         },
         {
           "include": "#attribute_access"
-        },
-        {
-          "include": "#structural_types"
         },
         {
           "include": "#functions"
@@ -684,89 +681,6 @@
           ]
         }
       }
-    },
-    "structural_types": {
-      "patterns": [
-        {
-          "begin": "(object)(\\()(\\{)\\s*",
-          "name": "meta.function-call.hcl",
-          "comment": "Object structural type",
-          "beginCaptures": {
-            "1": {
-              "name": "support.function.builtin.hcl"
-            },
-            "2": {
-              "name": "punctuation.section.parens.begin.hcl"
-            },
-            "3": {
-              "name": "punctuation.section.braces.begin.hcl"
-            }
-          },
-          "end": "(\\})(\\))",
-          "endCaptures": {
-            "1": {
-              "name": "punctuation.section.braces.end.hcl"
-            },
-            "2": {
-              "name": "punctuation.section.parens.end.hcl"
-            }
-          },
-          "patterns": [
-            {
-              "include": "#comma"
-            },
-            {
-              "match": "((?!null|false|true)[[:alpha:]][[:alnum:]_-]*)\\s*(\\=(?!\\=|\\>))\\s*",
-              "comment": "Identifier \"=\"",
-              "name": "variable.declaration.hcl",
-              "captures": {
-                "1": {
-                  "name": "variable.other.readwrite.hcl"
-                },
-                "2": {
-                  "name": "keyword.operator.assignment.hcl"
-                }
-              }
-            },
-            {
-              "include": "#hcl_type_keywords"
-            }
-          ]
-        },
-        {
-          "begin": "(tuple)(\\()(\\[)\\s*",
-          "name": "meta.function-call.hcl",
-          "comment": "Tuple structural type",
-          "beginCaptures": {
-            "1": {
-              "name": "support.function.builtin.hcl"
-            },
-            "2": {
-              "name": "punctuation.section.parens.begin.hcl"
-            },
-            "3": {
-              "name": "punctuation.section.brackets.begin.hcl"
-            }
-          },
-          "end": "(\\])(\\))",
-          "endCaptures": {
-            "1": {
-              "name": "punctuation.section.brackets.end.hcl"
-            },
-            "2": {
-              "name": "punctuation.section.parens.end.hcl"
-            }
-          },
-          "patterns": [
-            {
-              "include": "#comma"
-            },
-            {
-              "include": "#hcl_type_keywords"
-            }
-          ]
-        }
-      ]
     },
     "functions": {
       "begin": "(\\w+)(\\()",

--- a/syntaxes/terraform.tmGrammar.json
+++ b/syntaxes/terraform.tmGrammar.json
@@ -36,7 +36,7 @@
       "name": "variable.other.readwrite.hcl"
     },
     "hcl_type_keywords": {
-      "match": "\\b(any|string|number|bool)\\b",
+      "match": "\\b(any|string|number|bool|list|set|map|tuple|object)\\b",
       "comment": "Type keywords known to HCL.",
       "name": "storage.type.hcl"
     },
@@ -166,9 +166,6 @@
         },
         {
           "include": "#attribute_access"
-        },
-        {
-          "include": "#structural_types"
         },
         {
           "include": "#functions"
@@ -708,89 +705,6 @@
         }
       }
     },
-    "structural_types": {
-      "patterns": [
-        {
-          "begin": "(object)(\\()(\\{)\\s*",
-          "name": "meta.function-call.hcl",
-          "comment": "Object structural type",
-          "beginCaptures": {
-            "1": {
-              "name": "support.function.builtin.hcl"
-            },
-            "2": {
-              "name": "punctuation.section.parens.begin.hcl"
-            },
-            "3": {
-              "name": "punctuation.section.braces.begin.hcl"
-            }
-          },
-          "end": "(\\})(\\))",
-          "endCaptures": {
-            "1": {
-              "name": "punctuation.section.braces.end.hcl"
-            },
-            "2": {
-              "name": "punctuation.section.parens.end.hcl"
-            }
-          },
-          "patterns": [
-            {
-              "include": "#comma"
-            },
-            {
-              "match": "((?!null|false|true)[[:alpha:]][[:alnum:]_-]*)\\s*(\\=(?!\\=|\\>))\\s*",
-              "comment": "Identifier \"=\"",
-              "name": "variable.declaration.hcl",
-              "captures": {
-                "1": {
-                  "name": "variable.other.readwrite.hcl"
-                },
-                "2": {
-                  "name": "keyword.operator.assignment.hcl"
-                }
-              }
-            },
-            {
-              "include": "#hcl_type_keywords"
-            }
-          ]
-        },
-        {
-          "begin": "(tuple)(\\()(\\[)\\s*",
-          "name": "meta.function-call.hcl",
-          "comment": "Tuple structural type",
-          "beginCaptures": {
-            "1": {
-              "name": "support.function.builtin.hcl"
-            },
-            "2": {
-              "name": "punctuation.section.parens.begin.hcl"
-            },
-            "3": {
-              "name": "punctuation.section.brackets.begin.hcl"
-            }
-          },
-          "end": "(\\])(\\))",
-          "endCaptures": {
-            "1": {
-              "name": "punctuation.section.brackets.end.hcl"
-            },
-            "2": {
-              "name": "punctuation.section.parens.end.hcl"
-            }
-          },
-          "patterns": [
-            {
-              "include": "#comma"
-            },
-            {
-              "include": "#hcl_type_keywords"
-            }
-          ]
-        }
-      ]
-    },
     "functions": {
       "begin": "(\\w+)(\\()",
       "name": "meta.function-call.hcl",
@@ -799,7 +713,7 @@
         "1": {
           "patterns": [
             {
-              "match": "abspath|abs|ceil|floor|log|max|min|pow|signum|chomp|formatlist|indent|join|lower|regexall|regex|replace|split|strrev|substr|title|trimspace|upper|chunklist|coalescelist|coalesce|compact|concat|contains|distinct|element|flatten|index|keys|length|lookup|matchkeys|merge|range|reverse|setintersection|setproduct|setunion|slice|sort|transpose|values|zipmap|base64decode|base64encode|base64gzip|csvdecode|jsondecode|jsonencode|urlencode|yamldecode|yamlencode|dirname|pathexpand|basename|fileexists|fileset|filebase64|templatefile|formatdate|timeadd|timestamp|base64sha256|base64sha512|bcrypt|filebase64sha256|filebase64sha512|filemd5|filemd1|filesha256|filesha512|md5|rsadecrypt|sha1|sha256|sha512|uuidv5|uuid|cidrhost|cidrnetmask|cidrsubnet|tobool|tolist|tomap|tonumber|toset|tostring|file|format|map|list",
+              "match": "abspath|abs|ceil|floor|log|max|min|pow|signum|chomp|formatlist|indent|join|lower|regexall|regex|replace|split|strrev|substr|title|trimspace|upper|chunklist|coalescelist|coalesce|compact|concat|contains|distinct|element|flatten|index|keys|length|lookup|matchkeys|merge|range|reverse|setintersection|setproduct|setunion|slice|sort|transpose|values|zipmap|base64decode|base64encode|base64gzip|csvdecode|jsondecode|jsonencode|urlencode|yamldecode|yamlencode|dirname|pathexpand|basename|fileexists|fileset|filebase64|templatefile|formatdate|timeadd|timestamp|base64sha256|base64sha512|bcrypt|filebase64sha256|filebase64sha512|filemd5|filemd1|filesha256|filesha512|md5|rsadecrypt|sha1|sha256|sha512|uuidv5|uuid|cidrhost|cidrnetmask|cidrsubnet|tobool|tolist|tomap|tonumber|toset|tostring|file|format",
               "name": "support.function.builtin.terraform"
             }
           ]

--- a/tests/snapshot/hcl/issue19.hcl
+++ b/tests/snapshot/hcl/issue19.hcl
@@ -1,0 +1,10 @@
+variable "test" {
+  type = object({
+    test_object = map( # here
+      object({ # here
+        test_map = string
+      })
+    )
+  })
+}
+

--- a/tests/snapshot/hcl/issue19.hcl.snap
+++ b/tests/snapshot/hcl/issue19.hcl.snap
@@ -1,0 +1,45 @@
+>variable "test" {
+#^^^^^^^^ source.hcl meta.block.hcl entity.name.type.hcl
+#        ^ source.hcl meta.block.hcl
+#         ^^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#               ^ source.hcl meta.block.hcl
+#                ^ source.hcl meta.block.hcl punctuation.section.block.begin.hcl
+>  type = object({
+#^^ source.hcl meta.block.hcl
+#  ^^^^ source.hcl meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#      ^ source.hcl meta.block.hcl variable.declaration.hcl
+#       ^ source.hcl meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#        ^ source.hcl meta.block.hcl variable.declaration.hcl
+#         ^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl support.function.builtin.hcl
+#               ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
+#                ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.section.braces.begin.hcl
+>    test_object = map( # here
+#^^^^ source.hcl meta.block.hcl meta.function-call.hcl
+#    ^^^^^^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#               ^ source.hcl meta.block.hcl meta.function-call.hcl variable.declaration.hcl
+#                ^ source.hcl meta.block.hcl meta.function-call.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#                 ^ source.hcl meta.block.hcl meta.function-call.hcl variable.declaration.hcl
+#                  ^^^^^^^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl
+>      object({ # here
+#^^^^^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl
+>        test_map = string
+#^^^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl
+#        ^^^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#                ^ source.hcl meta.block.hcl meta.function-call.hcl variable.declaration.hcl
+#                 ^ source.hcl meta.block.hcl meta.function-call.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#                  ^ source.hcl meta.block.hcl meta.function-call.hcl variable.declaration.hcl
+#                   ^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl storage.type.hcl
+>      })
+#^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl
+#      ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.section.braces.end.hcl
+#       ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
+>    )
+#^^^^^^ source.hcl meta.block.hcl
+>  })
+#^^ source.hcl meta.block.hcl
+#  ^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
+#   ^^ source.hcl
+>}
+#^^ source.hcl
+>
+>

--- a/tests/snapshot/hcl/issue19.hcl.snap
+++ b/tests/snapshot/hcl/issue19.hcl.snap
@@ -10,36 +10,45 @@
 #      ^ source.hcl meta.block.hcl variable.declaration.hcl
 #       ^ source.hcl meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
 #        ^ source.hcl meta.block.hcl variable.declaration.hcl
-#         ^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl support.function.builtin.hcl
-#               ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
-#                ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.section.braces.begin.hcl
+#         ^^^^^^ source.hcl meta.block.hcl storage.type.hcl
+#               ^ source.hcl meta.block.hcl punctuation.section.parens.begin.hcl
+#                ^ source.hcl meta.block.hcl meta.braces.hcl punctuation.section.braces.begin.hcl
 >    test_object = map( # here
-#^^^^ source.hcl meta.block.hcl meta.function-call.hcl
-#    ^^^^^^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl variable.declaration.hcl variable.other.readwrite.hcl
-#               ^ source.hcl meta.block.hcl meta.function-call.hcl variable.declaration.hcl
-#                ^ source.hcl meta.block.hcl meta.function-call.hcl variable.declaration.hcl keyword.operator.assignment.hcl
-#                 ^ source.hcl meta.block.hcl meta.function-call.hcl variable.declaration.hcl
-#                  ^^^^^^^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl
+#^^^^ source.hcl meta.block.hcl meta.braces.hcl
+#    ^^^^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
+#               ^ source.hcl meta.block.hcl meta.braces.hcl
+#                ^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.assignment.hcl
+#                 ^ source.hcl meta.block.hcl meta.braces.hcl
+#                  ^^^ source.hcl meta.block.hcl meta.braces.hcl storage.type.hcl
+#                     ^^ source.hcl meta.block.hcl meta.braces.hcl
+#                       ^ source.hcl meta.block.hcl meta.braces.hcl comment.line.number-sign.hcl punctuation.definition.comment.hcl
+#                        ^^^^^ source.hcl meta.block.hcl meta.braces.hcl comment.line.number-sign.hcl
 >      object({ # here
-#^^^^^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl
+#^^^^^^ source.hcl meta.block.hcl meta.braces.hcl
+#      ^^^^^^ source.hcl meta.block.hcl meta.braces.hcl storage.type.hcl
+#            ^ source.hcl meta.block.hcl meta.braces.hcl
+#             ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl punctuation.section.braces.begin.hcl
+#              ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl
+#               ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl comment.line.number-sign.hcl punctuation.definition.comment.hcl
+#                ^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl comment.line.number-sign.hcl
 >        test_map = string
-#^^^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl
-#        ^^^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl variable.declaration.hcl variable.other.readwrite.hcl
-#                ^ source.hcl meta.block.hcl meta.function-call.hcl variable.declaration.hcl
-#                 ^ source.hcl meta.block.hcl meta.function-call.hcl variable.declaration.hcl keyword.operator.assignment.hcl
-#                  ^ source.hcl meta.block.hcl meta.function-call.hcl variable.declaration.hcl
-#                   ^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl storage.type.hcl
+#^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl
+#        ^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
+#                ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl
+#                 ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl keyword.operator.assignment.hcl
+#                  ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl
+#                   ^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl storage.type.hcl
 >      })
-#^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl
-#      ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.section.braces.end.hcl
-#       ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
+#^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl
+#      ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl punctuation.section.braces.end.hcl
+#       ^^ source.hcl meta.block.hcl meta.braces.hcl
 >    )
-#^^^^^^ source.hcl meta.block.hcl
+#^^^^^^ source.hcl meta.block.hcl meta.braces.hcl
 >  })
-#^^ source.hcl meta.block.hcl
-#  ^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
-#   ^^ source.hcl
+#^^ source.hcl meta.block.hcl meta.braces.hcl
+#  ^ source.hcl meta.block.hcl meta.braces.hcl punctuation.section.braces.end.hcl
+#   ^ source.hcl meta.block.hcl punctuation.section.parens.end.hcl
 >}
-#^^ source.hcl
+#^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
 >
 >

--- a/tests/snapshot/hcl/variables_input.hcl.snap
+++ b/tests/snapshot/hcl/variables_input.hcl.snap
@@ -30,10 +30,10 @@
 #      ^^^^ source.hcl meta.block.hcl variable.declaration.hcl
 #          ^ source.hcl meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
 #           ^ source.hcl meta.block.hcl variable.declaration.hcl
-#            ^^^^ source.hcl meta.block.hcl meta.function-call.hcl support.function.builtin.hcl
-#                ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
-#                 ^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl storage.type.hcl
-#                       ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
+#            ^^^^ source.hcl meta.block.hcl storage.type.hcl
+#                ^ source.hcl meta.block.hcl punctuation.section.parens.begin.hcl
+#                 ^^^^^^ source.hcl meta.block.hcl storage.type.hcl
+#                       ^ source.hcl meta.block.hcl punctuation.section.parens.end.hcl
 >  default = ["us-west-1a"]
 #^^ source.hcl meta.block.hcl
 #  ^^^^^^^ source.hcl meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
@@ -60,37 +60,37 @@
 #      ^ source.hcl meta.block.hcl variable.declaration.hcl
 #       ^ source.hcl meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
 #        ^ source.hcl meta.block.hcl variable.declaration.hcl
-#         ^^^^ source.hcl meta.block.hcl meta.function-call.hcl support.function.builtin.hcl
-#             ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
-#              ^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl support.function.builtin.hcl
-#                    ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
-#                     ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl punctuation.section.braces.begin.hcl
+#         ^^^^ source.hcl meta.block.hcl storage.type.hcl
+#             ^ source.hcl meta.block.hcl punctuation.section.parens.begin.hcl
+#              ^^^^^^ source.hcl meta.block.hcl storage.type.hcl
+#                    ^ source.hcl meta.block.hcl punctuation.section.parens.begin.hcl
+#                     ^ source.hcl meta.block.hcl meta.braces.hcl punctuation.section.braces.begin.hcl
 >    internal = number
-#^^^^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl
-#    ^^^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl variable.declaration.hcl variable.other.readwrite.hcl
-#            ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl variable.declaration.hcl
-#             ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl variable.declaration.hcl keyword.operator.assignment.hcl
-#              ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl variable.declaration.hcl
-#               ^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl storage.type.hcl
+#^^^^ source.hcl meta.block.hcl meta.braces.hcl
+#    ^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
+#            ^ source.hcl meta.block.hcl meta.braces.hcl
+#             ^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.assignment.hcl
+#              ^ source.hcl meta.block.hcl meta.braces.hcl
+#               ^^^^^^ source.hcl meta.block.hcl meta.braces.hcl storage.type.hcl
 >    external = number
-#^^^^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl
-#    ^^^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl variable.declaration.hcl variable.other.readwrite.hcl
-#            ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl variable.declaration.hcl
-#             ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl variable.declaration.hcl keyword.operator.assignment.hcl
-#              ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl variable.declaration.hcl
-#               ^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl storage.type.hcl
+#^^^^ source.hcl meta.block.hcl meta.braces.hcl
+#    ^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
+#            ^ source.hcl meta.block.hcl meta.braces.hcl
+#             ^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.assignment.hcl
+#              ^ source.hcl meta.block.hcl meta.braces.hcl
+#               ^^^^^^ source.hcl meta.block.hcl meta.braces.hcl storage.type.hcl
 >    protocol = string
-#^^^^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl
-#    ^^^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl variable.declaration.hcl variable.other.readwrite.hcl
-#            ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl variable.declaration.hcl
-#             ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl variable.declaration.hcl keyword.operator.assignment.hcl
-#              ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl variable.declaration.hcl
-#               ^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl storage.type.hcl
+#^^^^ source.hcl meta.block.hcl meta.braces.hcl
+#    ^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
+#            ^ source.hcl meta.block.hcl meta.braces.hcl
+#             ^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.assignment.hcl
+#              ^ source.hcl meta.block.hcl meta.braces.hcl
+#               ^^^^^^ source.hcl meta.block.hcl meta.braces.hcl storage.type.hcl
 >  }))
-#^^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl
-#  ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl punctuation.section.braces.end.hcl
-#   ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
-#    ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
+#^^ source.hcl meta.block.hcl meta.braces.hcl
+#  ^ source.hcl meta.block.hcl meta.braces.hcl punctuation.section.braces.end.hcl
+#   ^ source.hcl meta.block.hcl punctuation.section.parens.end.hcl
+#    ^ source.hcl meta.block.hcl punctuation.section.parens.end.hcl
 >  default = [
 #^^ source.hcl meta.block.hcl
 #  ^^^^^^^ source.hcl meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl

--- a/tests/snapshot/terraform/issue19.tf
+++ b/tests/snapshot/terraform/issue19.tf
@@ -1,0 +1,9 @@
+variable "test" {
+  type = object({
+    test_object = map( # here
+      object({ # here
+        test_map = string
+      })
+    )
+  })
+}

--- a/tests/snapshot/terraform/issue19.tf.snap
+++ b/tests/snapshot/terraform/issue19.tf.snap
@@ -1,0 +1,43 @@
+>variable "test" {
+#^^^^^^^^ source.hcl.terraform meta.block.hcl entity.name.type.terraform
+#        ^ source.hcl.terraform meta.block.hcl
+#         ^^^^^^ source.hcl.terraform meta.block.hcl variable.other.enummember.hcl
+#               ^ source.hcl.terraform meta.block.hcl
+#                ^ source.hcl.terraform meta.block.hcl punctuation.section.block.begin.hcl
+>  type = object({
+#^^ source.hcl.terraform meta.block.hcl
+#  ^^^^ source.hcl.terraform meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#      ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl
+#       ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#        ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl
+#         ^^^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl support.function.builtin.hcl
+#               ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
+#                ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl punctuation.section.braces.begin.hcl
+>    test_object = map( # here
+#^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl
+#    ^^^^^^^^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#               ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl variable.declaration.hcl
+#                ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#                 ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl variable.declaration.hcl
+#                  ^^^^^^^^^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl
+>      object({ # here
+#^^^^^^^^^^^^^^^^^^^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl
+>        test_map = string
+#^^^^^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl
+#        ^^^^^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#                ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl variable.declaration.hcl
+#                 ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#                  ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl variable.declaration.hcl
+#                   ^^^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl storage.type.hcl
+>      })
+#^^^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl
+#      ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl punctuation.section.braces.end.hcl
+#       ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
+>    )
+#^^^^^^ source.hcl.terraform meta.block.hcl
+>  })
+#^^ source.hcl.terraform meta.block.hcl
+#  ^ source.hcl.terraform meta.block.hcl punctuation.section.block.end.hcl
+#   ^^ source.hcl.terraform
+>}
+#^^ source.hcl.terraform

--- a/tests/snapshot/terraform/issue19.tf.snap
+++ b/tests/snapshot/terraform/issue19.tf.snap
@@ -10,34 +10,43 @@
 #      ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl
 #       ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
 #        ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl
-#         ^^^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl support.function.builtin.hcl
-#               ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
-#                ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl punctuation.section.braces.begin.hcl
+#         ^^^^^^ source.hcl.terraform meta.block.hcl storage.type.hcl
+#               ^ source.hcl.terraform meta.block.hcl punctuation.section.parens.begin.hcl
+#                ^ source.hcl.terraform meta.block.hcl meta.braces.hcl punctuation.section.braces.begin.hcl
 >    test_object = map( # here
-#^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl
-#    ^^^^^^^^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl variable.declaration.hcl variable.other.readwrite.hcl
-#               ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl variable.declaration.hcl
-#                ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl variable.declaration.hcl keyword.operator.assignment.hcl
-#                 ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl variable.declaration.hcl
-#                  ^^^^^^^^^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl
+#^^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl
+#    ^^^^^^^^^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
+#               ^ source.hcl.terraform meta.block.hcl meta.braces.hcl
+#                ^ source.hcl.terraform meta.block.hcl meta.braces.hcl keyword.operator.assignment.hcl
+#                 ^ source.hcl.terraform meta.block.hcl meta.braces.hcl
+#                  ^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl storage.type.hcl
+#                     ^^ source.hcl.terraform meta.block.hcl meta.braces.hcl
+#                       ^ source.hcl.terraform meta.block.hcl meta.braces.hcl comment.line.number-sign.hcl punctuation.definition.comment.hcl
+#                        ^^^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl comment.line.number-sign.hcl
 >      object({ # here
-#^^^^^^^^^^^^^^^^^^^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl
+#^^^^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl
+#      ^^^^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl storage.type.hcl
+#            ^ source.hcl.terraform meta.block.hcl meta.braces.hcl
+#             ^ source.hcl.terraform meta.block.hcl meta.braces.hcl meta.braces.hcl punctuation.section.braces.begin.hcl
+#              ^ source.hcl.terraform meta.block.hcl meta.braces.hcl meta.braces.hcl
+#               ^ source.hcl.terraform meta.block.hcl meta.braces.hcl meta.braces.hcl comment.line.number-sign.hcl punctuation.definition.comment.hcl
+#                ^^^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl meta.braces.hcl comment.line.number-sign.hcl
 >        test_map = string
-#^^^^^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl
-#        ^^^^^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl variable.declaration.hcl variable.other.readwrite.hcl
-#                ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl variable.declaration.hcl
-#                 ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl variable.declaration.hcl keyword.operator.assignment.hcl
-#                  ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl variable.declaration.hcl
-#                   ^^^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl storage.type.hcl
+#^^^^^^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl meta.braces.hcl
+#        ^^^^^^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
+#                ^ source.hcl.terraform meta.block.hcl meta.braces.hcl meta.braces.hcl
+#                 ^ source.hcl.terraform meta.block.hcl meta.braces.hcl meta.braces.hcl keyword.operator.assignment.hcl
+#                  ^ source.hcl.terraform meta.block.hcl meta.braces.hcl meta.braces.hcl
+#                   ^^^^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl meta.braces.hcl storage.type.hcl
 >      })
-#^^^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl
-#      ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl punctuation.section.braces.end.hcl
-#       ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
+#^^^^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl meta.braces.hcl
+#      ^ source.hcl.terraform meta.block.hcl meta.braces.hcl meta.braces.hcl punctuation.section.braces.end.hcl
+#       ^^ source.hcl.terraform meta.block.hcl meta.braces.hcl
 >    )
-#^^^^^^ source.hcl.terraform meta.block.hcl
+#^^^^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl
 >  })
-#^^ source.hcl.terraform meta.block.hcl
-#  ^ source.hcl.terraform meta.block.hcl punctuation.section.block.end.hcl
-#   ^^ source.hcl.terraform
+#^^ source.hcl.terraform meta.block.hcl meta.braces.hcl
+#  ^ source.hcl.terraform meta.block.hcl meta.braces.hcl punctuation.section.braces.end.hcl
+#   ^ source.hcl.terraform meta.block.hcl punctuation.section.parens.end.hcl
 >}
-#^^ source.hcl.terraform
+#^ source.hcl.terraform meta.block.hcl punctuation.section.block.end.hcl

--- a/tests/snapshot/terraform/variables_input.tf.snap
+++ b/tests/snapshot/terraform/variables_input.tf.snap
@@ -30,10 +30,10 @@
 #      ^^^^ source.hcl.terraform meta.block.hcl variable.declaration.hcl
 #          ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
 #           ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl
-#            ^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl support.function.builtin.terraform
-#                ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
-#                 ^^^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl storage.type.hcl
-#                       ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
+#            ^^^^ source.hcl.terraform meta.block.hcl storage.type.hcl
+#                ^ source.hcl.terraform meta.block.hcl punctuation.section.parens.begin.hcl
+#                 ^^^^^^ source.hcl.terraform meta.block.hcl storage.type.hcl
+#                       ^ source.hcl.terraform meta.block.hcl punctuation.section.parens.end.hcl
 >  default = ["us-west-1a"]
 #^^ source.hcl.terraform meta.block.hcl
 #  ^^^^^^^ source.hcl.terraform meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
@@ -60,37 +60,37 @@
 #      ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl
 #       ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
 #        ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl
-#         ^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl support.function.builtin.terraform
-#             ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
-#              ^^^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl meta.function-call.hcl support.function.builtin.hcl
-#                    ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
-#                     ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl meta.function-call.hcl punctuation.section.braces.begin.hcl
+#         ^^^^ source.hcl.terraform meta.block.hcl storage.type.hcl
+#             ^ source.hcl.terraform meta.block.hcl punctuation.section.parens.begin.hcl
+#              ^^^^^^ source.hcl.terraform meta.block.hcl storage.type.hcl
+#                    ^ source.hcl.terraform meta.block.hcl punctuation.section.parens.begin.hcl
+#                     ^ source.hcl.terraform meta.block.hcl meta.braces.hcl punctuation.section.braces.begin.hcl
 >    internal = number
-#^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl meta.function-call.hcl
-#    ^^^^^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl meta.function-call.hcl variable.declaration.hcl variable.other.readwrite.hcl
-#            ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl meta.function-call.hcl variable.declaration.hcl
-#             ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl meta.function-call.hcl variable.declaration.hcl keyword.operator.assignment.hcl
-#              ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl meta.function-call.hcl variable.declaration.hcl
-#               ^^^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl meta.function-call.hcl storage.type.hcl
+#^^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl
+#    ^^^^^^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
+#            ^ source.hcl.terraform meta.block.hcl meta.braces.hcl
+#             ^ source.hcl.terraform meta.block.hcl meta.braces.hcl keyword.operator.assignment.hcl
+#              ^ source.hcl.terraform meta.block.hcl meta.braces.hcl
+#               ^^^^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl storage.type.hcl
 >    external = number
-#^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl meta.function-call.hcl
-#    ^^^^^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl meta.function-call.hcl variable.declaration.hcl variable.other.readwrite.hcl
-#            ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl meta.function-call.hcl variable.declaration.hcl
-#             ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl meta.function-call.hcl variable.declaration.hcl keyword.operator.assignment.hcl
-#              ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl meta.function-call.hcl variable.declaration.hcl
-#               ^^^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl meta.function-call.hcl storage.type.hcl
+#^^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl
+#    ^^^^^^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
+#            ^ source.hcl.terraform meta.block.hcl meta.braces.hcl
+#             ^ source.hcl.terraform meta.block.hcl meta.braces.hcl keyword.operator.assignment.hcl
+#              ^ source.hcl.terraform meta.block.hcl meta.braces.hcl
+#               ^^^^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl storage.type.hcl
 >    protocol = string
-#^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl meta.function-call.hcl
-#    ^^^^^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl meta.function-call.hcl variable.declaration.hcl variable.other.readwrite.hcl
-#            ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl meta.function-call.hcl variable.declaration.hcl
-#             ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl meta.function-call.hcl variable.declaration.hcl keyword.operator.assignment.hcl
-#              ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl meta.function-call.hcl variable.declaration.hcl
-#               ^^^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl meta.function-call.hcl storage.type.hcl
+#^^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl
+#    ^^^^^^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
+#            ^ source.hcl.terraform meta.block.hcl meta.braces.hcl
+#             ^ source.hcl.terraform meta.block.hcl meta.braces.hcl keyword.operator.assignment.hcl
+#              ^ source.hcl.terraform meta.block.hcl meta.braces.hcl
+#               ^^^^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl storage.type.hcl
 >  }))
-#^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl meta.function-call.hcl
-#  ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl meta.function-call.hcl punctuation.section.braces.end.hcl
-#   ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
-#    ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
+#^^ source.hcl.terraform meta.block.hcl meta.braces.hcl
+#  ^ source.hcl.terraform meta.block.hcl meta.braces.hcl punctuation.section.braces.end.hcl
+#   ^ source.hcl.terraform meta.block.hcl punctuation.section.parens.end.hcl
+#    ^ source.hcl.terraform meta.block.hcl punctuation.section.parens.end.hcl
 >  default = [
 #^^ source.hcl.terraform meta.block.hcl
 #  ^^^^^^^ source.hcl.terraform meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl


### PR DESCRIPTION
This PR updates the HCL and the Terraform grammar to fix the highlighting of nested complex types.

## Before
<img width="338" alt="CleanShot 2022-03-17 at 13 01 08@2x" src="https://user-images.githubusercontent.com/45985/158804443-1a296a59-b6fa-4318-a943-e39f72f1c370.png">
<img width="286" alt="before-hcl" src="https://user-images.githubusercontent.com/45985/158804448-00c62f37-7597-4cde-b0f9-5c7ae959aafa.png">

## After
<img width="333" alt="CleanShot 2022-03-17 at 13 00 29@2x" src="https://user-images.githubusercontent.com/45985/158804426-d1e8ca03-5265-4337-a91a-5acd793cda78.png">
<img width="285" alt="after-hcl" src="https://user-images.githubusercontent.com/45985/158804432-0ebf703f-296d-4e40-a903-d35a1c546fa9.png">


Closes #19 