### PR TITLE
Add missing grammar updates to Terraform

### DIFF
--- a/syntaxes/terraform.tmGrammar.json
+++ b/syntaxes/terraform.tmGrammar.json
@@ -508,7 +508,7 @@
               "name": "punctuation.section.parens.begin.hcl"
             }
           },
-          "end": "(\\))\\s*(\\=)\\s*",
+          "end": "(\\))\\s*(=|:)\\s*",
           "endCaptures": {
             "1": {
               "name": "punctuation.section.parens.end.hcl"
@@ -842,10 +842,10 @@
       },
       "patterns": [
         {
-          "include": "#expressions"
+          "include": "#comments"
         },
         {
-          "include": "#local_identifiers"
+          "include": "#expressions"
         }
       ]
     }

--- a/tests/snapshot/terraform/issue809.tf
+++ b/tests/snapshot/terraform/issue809.tf
@@ -1,0 +1,10 @@
+locals {
+  key_name = "testing"
+  test_example = {
+    (local.key_name): "test"
+  }
+}
+
+variable "test" {
+  default = "test"
+}

--- a/tests/snapshot/terraform/issue809.tf.snap
+++ b/tests/snapshot/terraform/issue809.tf.snap
@@ -1,0 +1,55 @@
+>locals {
+#^^^^^^ source.hcl.terraform meta.block.hcl entity.name.type.terraform
+#      ^ source.hcl.terraform meta.block.hcl
+#       ^ source.hcl.terraform meta.block.hcl punctuation.section.block.begin.hcl
+>  key_name = "testing"
+#^^ source.hcl.terraform meta.block.hcl
+#  ^^^^^^^^ source.hcl.terraform meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#          ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl
+#           ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#            ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl
+#             ^ source.hcl.terraform meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#              ^^^^^^^ source.hcl.terraform meta.block.hcl string.quoted.double.hcl
+#                     ^ source.hcl.terraform meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+>  test_example = {
+#^^ source.hcl.terraform meta.block.hcl
+#  ^^^^^^^^^^^^ source.hcl.terraform meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#              ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl
+#               ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#                ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl
+#                 ^ source.hcl.terraform meta.block.hcl meta.braces.hcl punctuation.section.braces.begin.hcl
+>    (local.key_name): "test"
+#^^^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl meta.mapping.key.hcl punctuation.section.parens.begin.hcl
+#     ^^^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl meta.mapping.key.hcl support.constant.terraform
+#          ^ source.hcl.terraform meta.block.hcl meta.braces.hcl meta.mapping.key.hcl keyword.operator.accessor.hcl
+#           ^^^^^^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.member.hcl
+#                   ^ source.hcl.terraform meta.block.hcl meta.braces.hcl meta.mapping.key.hcl punctuation.section.parens.end.hcl
+#                    ^ source.hcl.terraform meta.block.hcl meta.braces.hcl meta.mapping.key.hcl keyword.operator.hcl
+#                     ^ source.hcl.terraform meta.block.hcl meta.braces.hcl meta.mapping.key.hcl
+#                      ^ source.hcl.terraform meta.block.hcl meta.braces.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                       ^^^^ source.hcl.terraform meta.block.hcl meta.braces.hcl string.quoted.double.hcl
+#                           ^ source.hcl.terraform meta.block.hcl meta.braces.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+>  }
+#^^ source.hcl.terraform meta.block.hcl meta.braces.hcl
+#  ^ source.hcl.terraform meta.block.hcl meta.braces.hcl punctuation.section.braces.end.hcl
+>}
+#^ source.hcl.terraform meta.block.hcl punctuation.section.block.end.hcl
+>
+>variable "test" {
+#^^^^^^^^ source.hcl.terraform meta.block.hcl entity.name.type.terraform
+#        ^ source.hcl.terraform meta.block.hcl
+#         ^^^^^^ source.hcl.terraform meta.block.hcl variable.other.enummember.hcl
+#               ^ source.hcl.terraform meta.block.hcl
+#                ^ source.hcl.terraform meta.block.hcl punctuation.section.block.begin.hcl
+>  default = "test"
+#^^ source.hcl.terraform meta.block.hcl
+#  ^^^^^^^ source.hcl.terraform meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#         ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl
+#          ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#           ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl
+#            ^ source.hcl.terraform meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#             ^^^^ source.hcl.terraform meta.block.hcl string.quoted.double.hcl
+#                 ^ source.hcl.terraform meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+>}
+#^ source.hcl.terraform meta.block.hcl punctuation.section.block.end.hcl
+>

--- a/tests/snapshot/terraform/issue941.tf
+++ b/tests/snapshot/terraform/issue941.tf
@@ -1,0 +1,17 @@
+instance_size = (                   #Comment
+  length(var.instance_size) > 0 ? ( #Comment
+    var.instance_size               #If instance size is provided, use it.
+  )                                 #Comment
+  :                                 #Comment
+  (var.insane_mode ?
+    lookup(local.insane_mode_instance_size_map, local.cloud, null) #If instance size is not provided and var.insane_mode is true, lookup in this table.
+    :                                                              #
+    lookup(local.instance_size_map, local.cloud, null)             #If instance size is not provided and var.insane_mode is false, lookup in this table.
+  )
+)
+
+# Comment
+
+variable "test" {
+  default = "test"
+}

--- a/tests/snapshot/terraform/issue941.tf.snap
+++ b/tests/snapshot/terraform/issue941.tf.snap
@@ -1,0 +1,127 @@
+>instance_size = (                   #Comment
+#^^^^^^^^^^^^^ source.hcl.terraform variable.declaration.hcl variable.other.readwrite.hcl
+#             ^ source.hcl.terraform variable.declaration.hcl
+#              ^ source.hcl.terraform variable.declaration.hcl keyword.operator.assignment.hcl
+#               ^ source.hcl.terraform variable.declaration.hcl
+#                ^ source.hcl.terraform punctuation.section.parens.begin.hcl
+#                 ^^^^^^^^^^^^^^^^^^^ source.hcl.terraform
+#                                    ^ source.hcl.terraform comment.line.number-sign.hcl punctuation.definition.comment.hcl
+#                                     ^^^^^^^ source.hcl.terraform comment.line.number-sign.hcl
+>  length(var.instance_size) > 0 ? ( #Comment
+#^^ source.hcl.terraform
+#  ^^^^^^ source.hcl.terraform meta.function-call.hcl support.function.builtin.terraform
+#        ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.begin.hcl
+#         ^^^ source.hcl.terraform meta.function-call.hcl support.constant.terraform
+#            ^ source.hcl.terraform meta.function-call.hcl keyword.operator.accessor.hcl
+#             ^^^^^^^^^^^^^ source.hcl.terraform meta.function-call.hcl variable.other.member.hcl
+#                          ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.end.hcl
+#                           ^ source.hcl.terraform
+#                            ^ source.hcl.terraform keyword.operator.hcl
+#                             ^ source.hcl.terraform
+#                              ^ source.hcl.terraform constant.numeric.integer.hcl
+#                               ^ source.hcl.terraform
+#                                ^ source.hcl.terraform keyword.operator.hcl
+#                                 ^ source.hcl.terraform
+#                                  ^ source.hcl.terraform punctuation.section.parens.begin.hcl
+#                                   ^ source.hcl.terraform
+#                                    ^ source.hcl.terraform comment.line.number-sign.hcl punctuation.definition.comment.hcl
+#                                     ^^^^^^^ source.hcl.terraform comment.line.number-sign.hcl
+>    var.instance_size               #If instance size is provided, use it.
+#^^^^ source.hcl.terraform
+#    ^^^ source.hcl.terraform support.constant.terraform
+#       ^ source.hcl.terraform keyword.operator.accessor.hcl
+#        ^^^^^^^^^^^^^ source.hcl.terraform variable.other.member.hcl
+#                     ^^^^^^^^^^^^^^^ source.hcl.terraform
+#                                    ^ source.hcl.terraform comment.line.number-sign.hcl punctuation.definition.comment.hcl
+#                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl.terraform comment.line.number-sign.hcl
+>  )                                 #Comment
+#^^ source.hcl.terraform
+#  ^ source.hcl.terraform punctuation.section.parens.end.hcl
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl.terraform
+#                                    ^ source.hcl.terraform comment.line.number-sign.hcl punctuation.definition.comment.hcl
+#                                     ^^^^^^^ source.hcl.terraform comment.line.number-sign.hcl
+>  :                                 #Comment
+#^^ source.hcl.terraform
+#  ^ source.hcl.terraform
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl.terraform
+#                                    ^ source.hcl.terraform comment.line.number-sign.hcl punctuation.definition.comment.hcl
+#                                     ^^^^^^^ source.hcl.terraform comment.line.number-sign.hcl
+>  (var.insane_mode ?
+#^^ source.hcl.terraform
+#  ^ source.hcl.terraform punctuation.section.parens.begin.hcl
+#   ^^^ source.hcl.terraform support.constant.terraform
+#      ^ source.hcl.terraform keyword.operator.accessor.hcl
+#       ^^^^^^^^^^^ source.hcl.terraform variable.other.member.hcl
+#                  ^ source.hcl.terraform
+#                   ^ source.hcl.terraform keyword.operator.hcl
+>    lookup(local.insane_mode_instance_size_map, local.cloud, null) #If instance size is not provided and var.insane_mode is true, lookup in this table.
+#^^^^ source.hcl.terraform
+#    ^^^^^^ source.hcl.terraform meta.function-call.hcl support.function.builtin.terraform
+#          ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.begin.hcl
+#           ^^^^^ source.hcl.terraform meta.function-call.hcl support.constant.terraform
+#                ^ source.hcl.terraform meta.function-call.hcl keyword.operator.accessor.hcl
+#                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl.terraform meta.function-call.hcl variable.other.member.hcl
+#                                              ^ source.hcl.terraform meta.function-call.hcl punctuation.separator.hcl
+#                                               ^ source.hcl.terraform meta.function-call.hcl
+#                                                ^^^^^ source.hcl.terraform meta.function-call.hcl support.constant.terraform
+#                                                     ^ source.hcl.terraform meta.function-call.hcl keyword.operator.accessor.hcl
+#                                                      ^^^^^ source.hcl.terraform meta.function-call.hcl variable.other.member.hcl
+#                                                           ^ source.hcl.terraform meta.function-call.hcl punctuation.separator.hcl
+#                                                            ^ source.hcl.terraform meta.function-call.hcl
+#                                                             ^^^^ source.hcl.terraform meta.function-call.hcl constant.language.hcl
+#                                                                 ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.end.hcl
+#                                                                  ^ source.hcl.terraform
+#                                                                   ^ source.hcl.terraform comment.line.number-sign.hcl punctuation.definition.comment.hcl
+#                                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl.terraform comment.line.number-sign.hcl
+>    :                                                              #
+#^^^^ source.hcl.terraform
+#    ^ source.hcl.terraform
+#     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl.terraform
+#                                                                   ^ source.hcl.terraform comment.line.number-sign.hcl punctuation.definition.comment.hcl
+>    lookup(local.instance_size_map, local.cloud, null)             #If instance size is not provided and var.insane_mode is false, lookup in this table.
+#^^^^ source.hcl.terraform
+#    ^^^^^^ source.hcl.terraform meta.function-call.hcl support.function.builtin.terraform
+#          ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.begin.hcl
+#           ^^^^^ source.hcl.terraform meta.function-call.hcl support.constant.terraform
+#                ^ source.hcl.terraform meta.function-call.hcl keyword.operator.accessor.hcl
+#                 ^^^^^^^^^^^^^^^^^ source.hcl.terraform meta.function-call.hcl variable.other.member.hcl
+#                                  ^ source.hcl.terraform meta.function-call.hcl punctuation.separator.hcl
+#                                   ^ source.hcl.terraform meta.function-call.hcl
+#                                    ^^^^^ source.hcl.terraform meta.function-call.hcl support.constant.terraform
+#                                         ^ source.hcl.terraform meta.function-call.hcl keyword.operator.accessor.hcl
+#                                          ^^^^^ source.hcl.terraform meta.function-call.hcl variable.other.member.hcl
+#                                               ^ source.hcl.terraform meta.function-call.hcl punctuation.separator.hcl
+#                                                ^ source.hcl.terraform meta.function-call.hcl
+#                                                 ^^^^ source.hcl.terraform meta.function-call.hcl constant.language.hcl
+#                                                     ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.end.hcl
+#                                                      ^^^^^^^^^^^^^ source.hcl.terraform
+#                                                                   ^ source.hcl.terraform comment.line.number-sign.hcl punctuation.definition.comment.hcl
+#                                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl.terraform comment.line.number-sign.hcl
+>  )
+#^^ source.hcl.terraform
+#  ^ source.hcl.terraform punctuation.section.parens.end.hcl
+>)
+#^ source.hcl.terraform punctuation.section.parens.end.hcl
+>
+># Comment
+#^ source.hcl.terraform comment.line.number-sign.hcl punctuation.definition.comment.hcl
+# ^^^^^^^^ source.hcl.terraform comment.line.number-sign.hcl
+>
+>variable "test" {
+#^^^^^^^^ source.hcl.terraform meta.block.hcl entity.name.type.terraform
+#        ^ source.hcl.terraform meta.block.hcl
+#         ^^^^^^ source.hcl.terraform meta.block.hcl variable.other.enummember.hcl
+#               ^ source.hcl.terraform meta.block.hcl
+#                ^ source.hcl.terraform meta.block.hcl punctuation.section.block.begin.hcl
+>  default = "test"
+#^^ source.hcl.terraform meta.block.hcl
+#  ^^^^^^^ source.hcl.terraform meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#         ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl
+#          ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#           ^ source.hcl.terraform meta.block.hcl variable.declaration.hcl
+#            ^ source.hcl.terraform meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#             ^^^^ source.hcl.terraform meta.block.hcl string.quoted.double.hcl
+#                 ^ source.hcl.terraform meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+>}
+#^ source.hcl.terraform meta.block.hcl punctuation.section.block.end.hcl
+>


### PR DESCRIPTION
I missed these two fixes from #8 and #9 while copying patterns from HCL to Terraform.