### PR TITLE
prepare release v0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "syntax",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "syntax",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MPL-2.0",
       "devDependencies": {
         "prettier": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syntax",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "HashiCorp TextMate grammar files",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Result of `npm version --no-git-tag-version v0.2.0`