### PR TITLE
Variables with no space between them break syntax highlighting

### DIFF
--- a/src/_main.yml
+++ b/src/_main.yml
@@ -148,11 +148,11 @@ repository:
       - include: "#string_interpolation"
       - include: "#char_escapes"
   string_interpolation:
-    begin: (\G|[^%$])([%$]{)
+    begin: '(?<![%$])([%$]{)'
     comment: String interpolation
     name: meta.interpolation.hcl
     beginCaptures:
-      "2":
+      "1":
         name: keyword.other.interpolation.begin.hcl
     end: \}
     endCaptures:

--- a/syntaxes/hcl.tmGrammar.json
+++ b/syntaxes/hcl.tmGrammar.json
@@ -677,11 +677,11 @@
     },
     "string_interpolation": {
       "name": "meta.interpolation.hcl",
-      "begin": "(\\G|[^%$])([%$]{)",
+      "begin": "(?<![%$])([%$]{)",
       "end": "\\}",
       "comment": "String interpolation",
       "beginCaptures": {
-        "2": {
+        "1": {
           "name": "keyword.other.interpolation.begin.hcl"
         }
       },

--- a/syntaxes/terraform.tmGrammar.json
+++ b/syntaxes/terraform.tmGrammar.json
@@ -701,11 +701,11 @@
     },
     "string_interpolation": {
       "name": "meta.interpolation.hcl",
-      "begin": "(\\G|[^%$])([%$]{)",
+      "begin": "(?<![%$])([%$]{)",
       "end": "\\}",
       "comment": "String interpolation",
       "beginCaptures": {
-        "2": {
+        "1": {
           "name": "keyword.other.interpolation.begin.hcl"
         }
       },

--- a/tests/snapshot/hcl/basic.hcl.snap
+++ b/tests/snapshot/hcl/basic.hcl.snap
@@ -112,8 +112,7 @@
 #        ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
 #         ^ source.hcl variable.declaration.hcl
 #          ^ source.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
-#           ^^^^^^ source.hcl string.quoted.double.hcl
-#                 ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl
+#           ^^^^^^^ source.hcl string.quoted.double.hcl
 #                  ^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
 #                    ^^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl variable.other.readwrite.hcl
 #                        ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl

--- a/tests/snapshot/hcl/expressions_for.hcl.snap
+++ b/tests/snapshot/hcl/expressions_for.hcl.snap
@@ -69,8 +69,7 @@
 #                         ^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
 #                           ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl variable.other.readwrite.hcl
 #                            ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
-#                             ^^^ source.hcl string.quoted.double.hcl
-#                                ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl
+#                             ^^^^ source.hcl string.quoted.double.hcl
 #                                 ^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
 #                                   ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl variable.other.readwrite.hcl
 #                                    ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl

--- a/tests/snapshot/hcl/expressions_functions.hcl.snap
+++ b/tests/snapshot/hcl/expressions_functions.hcl.snap
@@ -161,8 +161,7 @@
 #                                                                            ^ source.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
 >"  items: ${indent(2, "[\n  foo,\n  bar,\n]\n")}"
 #^ source.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
-# ^^^^^^^^ source.hcl string.quoted.double.hcl
-#         ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl
+# ^^^^^^^^^ source.hcl string.quoted.double.hcl
 #          ^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
 #            ^^^^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl meta.function-call.hcl support.function.builtin.hcl
 #                  ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl

--- a/tests/snapshot/hcl/expressions_strings.hcl.snap
+++ b/tests/snapshot/hcl/expressions_strings.hcl.snap
@@ -80,8 +80,7 @@
 >
 >"Hello, ${var.name}!"
 #^ source.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
-# ^^^^^^ source.hcl string.quoted.double.hcl
-#       ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl
+# ^^^^^^^ source.hcl string.quoted.double.hcl
 #        ^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
 #          ^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl variable.other.readwrite.hcl
 #             ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
@@ -92,8 +91,7 @@
 >
 >"Hello, %{ if var.name != "" }${var.name}%{ else }unnamed%{ endif }!"
 #^ source.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
-# ^^^^^^ source.hcl string.quoted.double.hcl
-#       ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl
+# ^^^^^^^ source.hcl string.quoted.double.hcl
 #        ^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
 #          ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl
 #           ^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.control.hcl
@@ -108,15 +106,17 @@
 #                           ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
 #                            ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl
 #                             ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
-#                              ^^^^^^^^^^ source.hcl string.quoted.double.hcl
-#                                        ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl
+#                              ^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
+#                                ^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl variable.other.readwrite.hcl
+#                                   ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#                                    ^^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
+#                                        ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
 #                                         ^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
 #                                           ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl
 #                                            ^^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.control.hcl
 #                                                ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl
 #                                                 ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
-#                                                  ^^^^^^ source.hcl string.quoted.double.hcl
-#                                                        ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl
+#                                                  ^^^^^^^ source.hcl string.quoted.double.hcl
 #                                                         ^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
 #                                                           ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl
 #                                                            ^^^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.control.hcl
@@ -146,8 +146,7 @@
 #                                              ^ source.hcl string.unquoted.heredoc.hcl meta.interpolation.hcl
 #                                               ^ source.hcl string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
 >server ${ip}
-#^^^^^^ source.hcl string.unquoted.heredoc.hcl
-#      ^ source.hcl string.unquoted.heredoc.hcl meta.interpolation.hcl
+#^^^^^^^ source.hcl string.unquoted.heredoc.hcl
 #       ^^ source.hcl string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
 #         ^^ source.hcl string.unquoted.heredoc.hcl meta.interpolation.hcl variable.other.readwrite.hcl
 #           ^ source.hcl string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
@@ -181,8 +180,7 @@
 #                                              ^^ source.hcl string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.operator.template.right.trim.hcl
 #                                                ^ source.hcl string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
 >server ${ip}
-#^^^^^^ source.hcl string.unquoted.heredoc.hcl
-#      ^ source.hcl string.unquoted.heredoc.hcl meta.interpolation.hcl
+#^^^^^^^ source.hcl string.unquoted.heredoc.hcl
 #       ^^ source.hcl string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
 #         ^^ source.hcl string.unquoted.heredoc.hcl meta.interpolation.hcl variable.other.readwrite.hcl
 #           ^ source.hcl string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl

--- a/tests/snapshot/terraform/expressions_for.tf.snap
+++ b/tests/snapshot/terraform/expressions_for.tf.snap
@@ -69,8 +69,7 @@
 #                         ^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
 #                           ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.readwrite.hcl
 #                            ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
-#                             ^^^ source.hcl.terraform string.quoted.double.hcl
-#                                ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl
+#                             ^^^^ source.hcl.terraform string.quoted.double.hcl
 #                                 ^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
 #                                   ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.readwrite.hcl
 #                                    ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl

--- a/tests/snapshot/terraform/expressions_functions.tf.snap
+++ b/tests/snapshot/terraform/expressions_functions.tf.snap
@@ -161,8 +161,7 @@
 #                                                                            ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.end.hcl
 >"  items: ${indent(2, "[\n  foo,\n  bar,\n]\n")}"
 #^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.begin.hcl
-# ^^^^^^^^ source.hcl.terraform string.quoted.double.hcl
-#         ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl
+# ^^^^^^^^^ source.hcl.terraform string.quoted.double.hcl
 #          ^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
 #            ^^^^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl meta.function-call.hcl support.function.builtin.terraform
 #                  ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl

--- a/tests/snapshot/terraform/expressions_strings.tf
+++ b/tests/snapshot/terraform/expressions_strings.tf
@@ -25,7 +25,7 @@ block {
   EOT
 }
 
-"Hello, ${var.name}!"
+"Hello, ${var.name}${var.name}!"
 
 "Hello, %{ if var.name != "" }${var.name}%{ else }unnamed%{ endif }!"
 

--- a/tests/snapshot/terraform/expressions_strings.tf.snap
+++ b/tests/snapshot/terraform/expressions_strings.tf.snap
@@ -80,8 +80,7 @@
 >
 >"Hello, ${var.name}!"
 #^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.begin.hcl
-# ^^^^^^ source.hcl.terraform string.quoted.double.hcl
-#       ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl
+# ^^^^^^^ source.hcl.terraform string.quoted.double.hcl
 #        ^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
 #          ^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.readwrite.terraform
 #             ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
@@ -92,8 +91,7 @@
 >
 >"Hello, %{ if var.name != "" }${var.name}%{ else }unnamed%{ endif }!"
 #^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.begin.hcl
-# ^^^^^^ source.hcl.terraform string.quoted.double.hcl
-#       ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl
+# ^^^^^^^ source.hcl.terraform string.quoted.double.hcl
 #        ^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
 #          ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl
 #           ^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.control.hcl
@@ -108,15 +106,17 @@
 #                           ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
 #                            ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl
 #                             ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
-#                              ^^^^^^^^^^ source.hcl.terraform string.quoted.double.hcl
-#                                        ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl
+#                              ^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
+#                                ^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.readwrite.terraform
+#                                   ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#                                    ^^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
+#                                        ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
 #                                         ^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
 #                                           ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl
 #                                            ^^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.control.hcl
 #                                                ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl
 #                                                 ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
-#                                                  ^^^^^^ source.hcl.terraform string.quoted.double.hcl
-#                                                        ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl
+#                                                  ^^^^^^^ source.hcl.terraform string.quoted.double.hcl
 #                                                         ^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
 #                                                           ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl
 #                                                            ^^^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.control.hcl
@@ -146,8 +146,7 @@
 #                                              ^ source.hcl.terraform string.unquoted.heredoc.hcl meta.interpolation.hcl
 #                                               ^ source.hcl.terraform string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
 >server ${ip}
-#^^^^^^ source.hcl.terraform string.unquoted.heredoc.hcl
-#      ^ source.hcl.terraform string.unquoted.heredoc.hcl meta.interpolation.hcl
+#^^^^^^^ source.hcl.terraform string.unquoted.heredoc.hcl
 #       ^^ source.hcl.terraform string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
 #         ^^ source.hcl.terraform string.unquoted.heredoc.hcl meta.interpolation.hcl variable.other.readwrite.hcl
 #           ^ source.hcl.terraform string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
@@ -181,8 +180,7 @@
 #                                              ^^ source.hcl.terraform string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.operator.template.right.trim.hcl
 #                                                ^ source.hcl.terraform string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
 >server ${ip}
-#^^^^^^ source.hcl.terraform string.unquoted.heredoc.hcl
-#      ^ source.hcl.terraform string.unquoted.heredoc.hcl meta.interpolation.hcl
+#^^^^^^^ source.hcl.terraform string.unquoted.heredoc.hcl
 #       ^^ source.hcl.terraform string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
 #         ^^ source.hcl.terraform string.unquoted.heredoc.hcl meta.interpolation.hcl variable.other.readwrite.hcl
 #           ^ source.hcl.terraform string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl

--- a/tests/snapshot/terraform/expressions_strings.tf.snap
+++ b/tests/snapshot/terraform/expressions_strings.tf.snap
@@ -78,7 +78,7 @@
 >}
 #^ source.hcl.terraform meta.block.hcl punctuation.section.block.end.hcl
 >
->"Hello, ${var.name}!"
+>"Hello, ${var.name}${var.name}!"
 #^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.begin.hcl
 # ^^^^^^^ source.hcl.terraform string.quoted.double.hcl
 #        ^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
@@ -86,8 +86,13 @@
 #             ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
 #              ^^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
 #                  ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
-#                   ^ source.hcl.terraform string.quoted.double.hcl
-#                    ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                   ^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
+#                     ^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.readwrite.terraform
+#                        ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#                         ^^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
+#                             ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
+#                              ^ source.hcl.terraform string.quoted.double.hcl
+#                               ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.end.hcl
 >
 >"Hello, %{ if var.name != "" }${var.name}%{ else }unnamed%{ endif }!"
 #^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.begin.hcl


### PR DESCRIPTION
Closes #31.

Tests output:
```
$ npm test

> syntax@0.2.0 test
> npm run test:snap


> syntax@0.2.0 test:snap
> npm run test:snap:hcl && npm run test:snap:sentinel && npm run test:snap:terraform


> syntax@0.2.0 test:snap:hcl
> npx vscode-tmgrammar-snap -s source.hcl -g syntaxes/hcl.tmGrammar.json -t "tests/snapshot/hcl/*.hcl"

✓ tests/snapshot/hcl/basic.hcl run successfully.
✓ tests/snapshot/hcl/blocks.hcl run successfully.
✓ tests/snapshot/hcl/comments.hcl run successfully.
✓ tests/snapshot/hcl/data_sources.hcl run successfully.
✓ tests/snapshot/hcl/expressions_conditional.hcl run successfully.
✓ tests/snapshot/hcl/expressions_dynamic.hcl run successfully.
✓ tests/snapshot/hcl/expressions_for.hcl run successfully.
Generating snapshot tests/snapshot/hcl/expressions_functions.hcl.snap
✓ tests/snapshot/hcl/expressions_operators.hcl run successfully.
✓ tests/snapshot/hcl/expressions_splat.hcl run successfully.
✓ tests/snapshot/hcl/expressions_strings.hcl run successfully.
✓ tests/snapshot/hcl/issue19.hcl run successfully.
✓ tests/snapshot/hcl/issue809.hcl run successfully.
✓ tests/snapshot/hcl/issue927.hcl run successfully.
✓ tests/snapshot/hcl/issue941.hcl run successfully.
✓ tests/snapshot/hcl/modules.hcl run successfully.
✓ tests/snapshot/hcl/nested_maps.hcl run successfully.
✓ tests/snapshot/hcl/providers.hcl run successfully.
✓ tests/snapshot/hcl/variables_input.hcl run successfully.
✓ tests/snapshot/hcl/variables_local.hcl run successfully.
✓ tests/snapshot/hcl/variables_output.hcl run successfully.

> syntax@0.2.0 test:snap:sentinel
> npx vscode-tmgrammar-snap -s source.sentinel -g syntaxes/sentinel.tmGrammar.json -t "tests/snapshot/sentinel/*.sentinel"

✓ tests/snapshot/sentinel/basic.sentinel run successfully.

> syntax@0.2.0 test:snap:terraform
> npx vscode-tmgrammar-snap -s source.hcl.terraform -g syntaxes/terraform.tmGrammar.json  -g syntaxes/hcl.tmGrammar.json -t "tests/snapshot/terraform/*.tf"

✓ tests/snapshot/terraform/basic.tf run successfully.
✓ tests/snapshot/terraform/blocks.tf run successfully.
✓ tests/snapshot/terraform/comments.tf run successfully.
✓ tests/snapshot/terraform/data_sources.tf run successfully.
✓ tests/snapshot/terraform/expressions_conditional.tf run successfully.
✓ tests/snapshot/terraform/expressions_dynamic.tf run successfully.
✓ tests/snapshot/terraform/expressions_for.tf run successfully.
✓ tests/snapshot/terraform/expressions_functions.tf run successfully.
✓ tests/snapshot/terraform/expressions_operators.tf run successfully.
✓ tests/snapshot/terraform/expressions_splat.tf run successfully.
✓ tests/snapshot/terraform/expressions_strings.tf run successfully.
✓ tests/snapshot/terraform/issue19.tf run successfully.
✓ tests/snapshot/terraform/issue809.tf run successfully.
✓ tests/snapshot/terraform/issue927.tf run successfully.
✓ tests/snapshot/terraform/issue941.tf run successfully.
✓ tests/snapshot/terraform/modules.tf run successfully.
✓ tests/snapshot/terraform/nested_maps.tf run successfully.
✓ tests/snapshot/terraform/providers.tf run successfully.
✓ tests/snapshot/terraform/variables_input.tf run successfully.
✓ tests/snapshot/terraform/variables_local.tf run successfully.
✓ tests/snapshot/terraform/variables_output.tf run successfully.
```

Before:
<img width="561" alt="before" src="https://user-images.githubusercontent.com/22010517/166467107-550edc35-6793-4fe7-be02-7b4052b28a19.png">

After:
<img width="592" alt="after" src="https://user-images.githubusercontent.com/22010517/166467150-1a8e0753-478f-4286-ae8b-822c8fc2ba12.png">
