### PR TITLE
chore: add HCL VS Code extension link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Generally you should never need to interact with this repository directly.
 Instead you can use the grammar through editors, editor extensions, or highlighting libraries which in turn may use this repository, for example:
 
  - [Terraform VS Code Extension](https://marketplace.visualstudio.com/items?itemName=HashiCorp.terraform)
- - _Coming soon: HCL VS Code Extension_
- -  [Sentinel VS Code Extension](https://marketplace.visualstudio.com/items?itemName=HashiCorp.sentinel)
+ - [HCL VS Code Extension](https://marketplace.visualstudio.com/items?itemName=HashiCorp.HCL)
+ - [Sentinel VS Code Extension](https://marketplace.visualstudio.com/items?itemName=HashiCorp.sentinel)
 
 ### As maintainer enabling end-users
 


### PR DESCRIPTION
This updates the README to link to the newly-announced official HCL VS Code extension: https://www.hashicorp.com/blog/announcing-the-hcl-extension-for-visual-studio-code-0-1