### PR TITLE
Fix highlighting of `.0`, `.*` attribute access and `[*]` brackets

### DIFF
--- a/src/_main.yml
+++ b/src/_main.yml
@@ -105,6 +105,7 @@ repository:
       - include: "#brackets"
       - include: "#objects"
       - include: "#attribute_access"
+      - include: "#attribute_splat"
       - include: "#functions"
       - include: "#parens"
   literal_values:
@@ -227,13 +228,14 @@ repository:
     beginCaptures:
       "0":
         name: punctuation.section.brackets.begin.hcl
-    end: (\*?)\]
+    end: \]
     endCaptures:
       "0":
         name: punctuation.section.brackets.end.hcl
-      "1":
-        name: keyword.operator.splat.hcl
     patterns:
+      - match: \*
+        comment: Splat operator
+        name: keyword.operator.splat.hcl
       - include: "#comma"
       - include: "#comments"
       - include: "#inline_for_expression"
@@ -290,6 +292,7 @@ repository:
             name: keyword.operator.hcl
         patterns:
           - include: "#attribute_access"
+          - include: "#attribute_splat"
       - include: "#object_key_values"
   object_key_values:
     patterns:
@@ -366,24 +369,31 @@ repository:
       - include: "#comma"
       - include: "#local_identifiers"
   attribute_access:
-    begin: \.
+    begin: \.(?!\*)
     beginCaptures:
       "0":
         name: keyword.operator.accessor.hcl
-    end: "[[:alpha:]][[:alnum:]_-]*(\\[[0-9\\*]+\\])?"
-    comment: Matches a variable with an optional splat or index ([*]/[0])
+    end: '[[:alpha:]][\w-]*|\d*'
+    comment: Matches traversal attribute access such as .attr
     endCaptures:
       "0":
         patterns:
-          - match: \b(?!null|false|true)[[:alpha:]][[:alnum:]_-]*\b
-            comment: Attribute name including - and _
+          - match: (?!null|false|true)[[:alpha:]][\w-]*
+            comment: Attribute name
             name: variable.other.member.hcl
           - match: \d+
             comment: Optional attribute index
             name: constant.numeric.integer.hcl
-          - match: \*
-            comment: Optional attribute-only splat
-            name: keyword.operator.splat.hcl
+  attribute_splat:
+    begin: \.
+    end: \*
+    comment: Legacy attribute-only splat
+    beginCaptures:
+      "0":
+        name: keyword.operator.accessor.hcl
+    endCaptures:
+      "0":
+        name: keyword.operator.splat.hcl
   functions:
     begin: (\w+)(\()
     name: meta.function-call.hcl

--- a/syntaxes/hcl.tmGrammar.json
+++ b/syntaxes/hcl.tmGrammar.json
@@ -21,9 +21,9 @@
   ],
   "repository": {
     "attribute_access": {
-      "begin": "\\.",
-      "end": "[[:alpha:]][[:alnum:]_-]*(\\[[0-9\\*]+\\])?",
-      "comment": "Matches a variable with an optional splat or index ([*]/[0])",
+      "begin": "\\.(?!\\*)",
+      "end": "[[:alpha:]][\\w-]*|\\d*",
+      "comment": "Matches traversal attribute access such as .attr",
       "beginCaptures": {
         "0": {
           "name": "keyword.operator.accessor.hcl"
@@ -33,19 +33,14 @@
         "0": {
           "patterns": [
             {
-              "match": "\\b(?!null|false|true)[[:alpha:]][[:alnum:]_-]*\\b",
-              "comment": "Attribute name including - and _",
+              "match": "(?!null|false|true)[[:alpha:]][\\w-]*",
+              "comment": "Attribute name",
               "name": "variable.other.member.hcl"
             },
             {
               "match": "\\d+",
               "comment": "Optional attribute index",
               "name": "constant.numeric.integer.hcl"
-            },
-            {
-              "match": "\\*",
-              "comment": "Optional attribute-only splat",
-              "name": "keyword.operator.splat.hcl"
             }
           ]
         }
@@ -67,6 +62,21 @@
         },
         "4": {
           "name": "keyword.operator.assignment.hcl"
+        }
+      }
+    },
+    "attribute_splat": {
+      "begin": "\\.",
+      "end": "\\*",
+      "comment": "Legacy attribute-only splat",
+      "beginCaptures": {
+        "0": {
+          "name": "keyword.operator.accessor.hcl"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "keyword.operator.splat.hcl"
         }
       }
     },
@@ -131,7 +141,7 @@
     },
     "brackets": {
       "begin": "\\[",
-      "end": "(\\*?)\\]",
+      "end": "\\]",
       "beginCaptures": {
         "0": {
           "name": "punctuation.section.brackets.begin.hcl"
@@ -140,12 +150,14 @@
       "endCaptures": {
         "0": {
           "name": "punctuation.section.brackets.end.hcl"
-        },
-        "1": {
-          "name": "keyword.operator.splat.hcl"
         }
       },
       "patterns": [
+        {
+          "name": "keyword.operator.splat.hcl",
+          "match": "\\*",
+          "comment": "Splat operator"
+        },
         {
           "include": "#comma"
         },
@@ -222,6 +234,9 @@
         },
         {
           "include": "#attribute_access"
+        },
+        {
+          "include": "#attribute_splat"
         },
         {
           "include": "#functions"
@@ -573,6 +588,9 @@
           "patterns": [
             {
               "include": "#attribute_access"
+            },
+            {
+              "include": "#attribute_splat"
             }
           ]
         },

--- a/syntaxes/terraform.tmGrammar.json
+++ b/syntaxes/terraform.tmGrammar.json
@@ -22,9 +22,9 @@
   ],
   "repository": {
     "attribute_access": {
-      "begin": "\\.",
-      "end": "[[:alpha:]][[:alnum:]_-]*(\\[[0-9\\*]+\\])?",
-      "comment": "Matches a variable with an optional splat or index ([*]/[0])",
+      "begin": "\\.(?!\\*)",
+      "end": "[[:alpha:]][\\w-]*|\\d*",
+      "comment": "Matches traversal attribute access such as .attr",
       "beginCaptures": {
         "0": {
           "name": "keyword.operator.accessor.hcl"
@@ -34,19 +34,14 @@
         "0": {
           "patterns": [
             {
-              "match": "\\b(?!null|false|true)[[:alpha:]][[:alnum:]_-]*\\b",
-              "comment": "Attribute name including - and _",
+              "match": "(?!null|false|true)[[:alpha:]][\\w-]*",
+              "comment": "Attribute name",
               "name": "variable.other.member.hcl"
             },
             {
               "match": "\\d+",
               "comment": "Optional attribute index",
               "name": "constant.numeric.integer.hcl"
-            },
-            {
-              "match": "\\*",
-              "comment": "Optional attribute-only splat",
-              "name": "keyword.operator.splat.hcl"
             }
           ]
         }
@@ -68,6 +63,21 @@
         },
         "4": {
           "name": "keyword.operator.assignment.hcl"
+        }
+      }
+    },
+    "attribute_splat": {
+      "begin": "\\.",
+      "end": "\\*",
+      "comment": "Legacy attribute-only splat",
+      "beginCaptures": {
+        "0": {
+          "name": "keyword.operator.accessor.hcl"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "keyword.operator.splat.hcl"
         }
       }
     },
@@ -137,7 +147,7 @@
     },
     "brackets": {
       "begin": "\\[",
-      "end": "(\\*?)\\]",
+      "end": "\\]",
       "beginCaptures": {
         "0": {
           "name": "punctuation.section.brackets.begin.hcl"
@@ -146,12 +156,14 @@
       "endCaptures": {
         "0": {
           "name": "punctuation.section.brackets.end.hcl"
-        },
-        "1": {
-          "name": "keyword.operator.splat.hcl"
         }
       },
       "patterns": [
+        {
+          "name": "keyword.operator.splat.hcl",
+          "match": "\\*",
+          "comment": "Splat operator"
+        },
         {
           "include": "#comma"
         },
@@ -228,6 +240,9 @@
         },
         {
           "include": "#attribute_access"
+        },
+        {
+          "include": "#attribute_splat"
         },
         {
           "include": "#functions"

--- a/tests/snapshot/hcl/expressions_splat.hcl
+++ b/tests/snapshot/hcl/expressions_splat.hcl
@@ -1,5 +1,5 @@
-[for o in var.list : o.id]
+attr = [for o in var.list : o.id]
 
-var.list[*].id
+attr = var.list[*].id
 
-var.list[*].interfaces[0].name
+attr = var.list[*].interfaces[0].name

--- a/tests/snapshot/hcl/expressions_splat.hcl
+++ b/tests/snapshot/hcl/expressions_splat.hcl
@@ -3,3 +3,11 @@ attr = [for o in var.list : o.id]
 attr = var.list[*].id
 
 attr = var.list[*].interfaces[0].name
+
+attr = var.list.*.id
+
+attr = "${var.list.*.id}"
+
+attr = "${var.list.*}"
+
+attr = var.list.*

--- a/tests/snapshot/hcl/expressions_splat.hcl.snap
+++ b/tests/snapshot/hcl/expressions_splat.hcl.snap
@@ -29,9 +29,9 @@
 #       ^^^ source.hcl
 #          ^ source.hcl keyword.operator.accessor.hcl
 #           ^^^^ source.hcl variable.other.member.hcl
-#               ^ source.hcl
+#               ^ source.hcl punctuation.section.brackets.begin.hcl
 #                ^ source.hcl keyword.operator.splat.hcl
-#                 ^ source.hcl
+#                 ^ source.hcl punctuation.section.brackets.end.hcl
 #                  ^ source.hcl keyword.operator.accessor.hcl
 #                   ^^ source.hcl variable.other.member.hcl
 >
@@ -43,14 +43,70 @@
 #       ^^^ source.hcl
 #          ^ source.hcl keyword.operator.accessor.hcl
 #           ^^^^ source.hcl variable.other.member.hcl
-#               ^ source.hcl
+#               ^ source.hcl punctuation.section.brackets.begin.hcl
 #                ^ source.hcl keyword.operator.splat.hcl
-#                 ^ source.hcl
+#                 ^ source.hcl punctuation.section.brackets.end.hcl
 #                  ^ source.hcl keyword.operator.accessor.hcl
 #                   ^^^^^^^^^^ source.hcl variable.other.member.hcl
-#                             ^ source.hcl
+#                             ^ source.hcl punctuation.section.brackets.begin.hcl
 #                              ^ source.hcl constant.numeric.integer.hcl
-#                               ^ source.hcl
+#                               ^ source.hcl punctuation.section.brackets.end.hcl
 #                                ^ source.hcl keyword.operator.accessor.hcl
 #                                 ^^^^ source.hcl variable.other.member.hcl
+>
+>attr = var.list.*.id
+#^^^^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl variable.declaration.hcl
+#     ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl variable.declaration.hcl
+#       ^^^ source.hcl
+#          ^ source.hcl keyword.operator.accessor.hcl
+#           ^^^^ source.hcl variable.other.member.hcl
+#               ^ source.hcl keyword.operator.accessor.hcl
+#                ^ source.hcl keyword.operator.splat.hcl
+#                 ^ source.hcl keyword.operator.accessor.hcl
+#                  ^^ source.hcl variable.other.member.hcl
+>
+>attr = "${var.list.*.id}"
+#^^^^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl variable.declaration.hcl
+#     ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl variable.declaration.hcl
+#       ^ source.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#        ^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
+#          ^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl variable.other.readwrite.hcl
+#             ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#              ^^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
+#                  ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#                   ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.operator.splat.hcl
+#                    ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#                     ^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
+#                       ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
+#                        ^ source.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+>
+>attr = "${var.list.*}"
+#^^^^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl variable.declaration.hcl
+#     ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl variable.declaration.hcl
+#       ^ source.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#        ^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
+#          ^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl variable.other.readwrite.hcl
+#             ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#              ^^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
+#                  ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#                   ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.operator.splat.hcl
+#                    ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
+#                     ^ source.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+>
+>attr = var.list.*
+#^^^^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl variable.declaration.hcl
+#     ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl variable.declaration.hcl
+#       ^^^ source.hcl
+#          ^ source.hcl keyword.operator.accessor.hcl
+#           ^^^^ source.hcl variable.other.member.hcl
+#               ^ source.hcl keyword.operator.accessor.hcl
+#                ^ source.hcl keyword.operator.splat.hcl
 >

--- a/tests/snapshot/hcl/expressions_splat.hcl.snap
+++ b/tests/snapshot/hcl/expressions_splat.hcl.snap
@@ -1,44 +1,56 @@
->[for o in var.list : o.id]
-#^ source.hcl punctuation.section.brackets.begin.hcl
-# ^^^ source.hcl keyword.control.hcl
-#    ^ source.hcl
-#     ^ source.hcl variable.other.readwrite.hcl
-#      ^ source.hcl
-#       ^^ source.hcl keyword.operator.word.hcl
-#         ^ source.hcl
-#          ^^^ source.hcl variable.other.readwrite.hcl
-#             ^ source.hcl keyword.operator.accessor.hcl
-#              ^^^^ source.hcl variable.other.member.hcl
-#                  ^ source.hcl
-#                   ^ source.hcl keyword.operator.hcl
-#                    ^ source.hcl
-#                     ^ source.hcl variable.other.readwrite.hcl
-#                      ^ source.hcl keyword.operator.accessor.hcl
-#                       ^^ source.hcl variable.other.member.hcl
-#                         ^ source.hcl punctuation.section.brackets.end.hcl
+>attr = [for o in var.list : o.id]
+#^^^^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl variable.declaration.hcl
+#     ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl variable.declaration.hcl
+#       ^ source.hcl punctuation.section.brackets.begin.hcl
+#        ^^^ source.hcl keyword.control.hcl
+#           ^ source.hcl
+#            ^ source.hcl variable.other.readwrite.hcl
+#             ^ source.hcl
+#              ^^ source.hcl keyword.operator.word.hcl
+#                ^ source.hcl
+#                 ^^^ source.hcl variable.other.readwrite.hcl
+#                    ^ source.hcl keyword.operator.accessor.hcl
+#                     ^^^^ source.hcl variable.other.member.hcl
+#                         ^ source.hcl
+#                          ^ source.hcl keyword.operator.hcl
+#                           ^ source.hcl
+#                            ^ source.hcl variable.other.readwrite.hcl
+#                             ^ source.hcl keyword.operator.accessor.hcl
+#                              ^^ source.hcl variable.other.member.hcl
+#                                ^ source.hcl punctuation.section.brackets.end.hcl
 >
->var.list[*].id
-#^^^ source.hcl
-#   ^ source.hcl keyword.operator.accessor.hcl
-#    ^^^^ source.hcl variable.other.member.hcl
-#        ^ source.hcl
-#         ^ source.hcl keyword.operator.splat.hcl
-#          ^ source.hcl
-#           ^ source.hcl keyword.operator.accessor.hcl
-#            ^^ source.hcl variable.other.member.hcl
+>attr = var.list[*].id
+#^^^^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl variable.declaration.hcl
+#     ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl variable.declaration.hcl
+#       ^^^ source.hcl
+#          ^ source.hcl keyword.operator.accessor.hcl
+#           ^^^^ source.hcl variable.other.member.hcl
+#               ^ source.hcl
+#                ^ source.hcl keyword.operator.splat.hcl
+#                 ^ source.hcl
+#                  ^ source.hcl keyword.operator.accessor.hcl
+#                   ^^ source.hcl variable.other.member.hcl
 >
->var.list[*].interfaces[0].name
-#^^^ source.hcl
-#   ^ source.hcl keyword.operator.accessor.hcl
-#    ^^^^ source.hcl variable.other.member.hcl
-#        ^ source.hcl
-#         ^ source.hcl keyword.operator.splat.hcl
-#          ^ source.hcl
-#           ^ source.hcl keyword.operator.accessor.hcl
-#            ^^^^^^^^^^ source.hcl variable.other.member.hcl
-#                      ^ source.hcl
-#                       ^ source.hcl constant.numeric.integer.hcl
-#                        ^ source.hcl
-#                         ^ source.hcl keyword.operator.accessor.hcl
-#                          ^^^^ source.hcl variable.other.member.hcl
+>attr = var.list[*].interfaces[0].name
+#^^^^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl variable.declaration.hcl
+#     ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl variable.declaration.hcl
+#       ^^^ source.hcl
+#          ^ source.hcl keyword.operator.accessor.hcl
+#           ^^^^ source.hcl variable.other.member.hcl
+#               ^ source.hcl
+#                ^ source.hcl keyword.operator.splat.hcl
+#                 ^ source.hcl
+#                  ^ source.hcl keyword.operator.accessor.hcl
+#                   ^^^^^^^^^^ source.hcl variable.other.member.hcl
+#                             ^ source.hcl
+#                              ^ source.hcl constant.numeric.integer.hcl
+#                               ^ source.hcl
+#                                ^ source.hcl keyword.operator.accessor.hcl
+#                                 ^^^^ source.hcl variable.other.member.hcl
 >

--- a/tests/snapshot/hcl/expressions_strings.hcl
+++ b/tests/snapshot/hcl/expressions_strings.hcl
@@ -1,10 +1,10 @@
-"hello"
+attr = "hello"
 
-"\n\r\t\"\\"
+attr = "\n\r\t\"\\"
 
-"$${}"
+attr = "$${}"
 
-"%%{}"
+attr = "%%{}"
 
 thing = <<EOT
 hello
@@ -25,17 +25,17 @@ block {
   EOT
 }
 
-"Hello, ${var.name}!"
+attr = "Hello, ${var.name}!"
 
-"Hello, %{ if var.name != "" }${var.name}%{ else }unnamed%{ endif }!"
+attr = "Hello, %{ if var.name != "" }${var.name}%{ else }unnamed%{ endif }!"
 
-<<EOT
+attr = <<EOT
 %{ for ip in aws_instance.example.*.private_ip }
 server ${ip}
 %{ endfor }
 EOT
 
-<<EOT
+attr = <<EOT
 %{ for ip in aws_instance.example.*.private_ip ~}
 server ${ip}
 %{ endfor ~}

--- a/tests/snapshot/hcl/expressions_strings.hcl
+++ b/tests/snapshot/hcl/expressions_strings.hcl
@@ -41,4 +41,8 @@ server ${ip}
 %{ endfor ~}
 EOT
 
+attr = "abc${var.name.multi.step.addr}"
 
+attr = "abc${var.name.test.0.foo}"
+
+attr = "abc${var.name.test.0}"

--- a/tests/snapshot/hcl/expressions_strings.hcl.snap
+++ b/tests/snapshot/hcl/expressions_strings.hcl.snap
@@ -169,7 +169,8 @@
 #                         ^ source.hcl string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
 #                          ^^^^^^^ source.hcl string.unquoted.heredoc.hcl meta.interpolation.hcl variable.other.member.hcl
 #                                 ^ source.hcl string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
-#                                  ^^ source.hcl string.unquoted.heredoc.hcl meta.interpolation.hcl
+#                                  ^ source.hcl string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.operator.splat.hcl
+#                                   ^ source.hcl string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
 #                                    ^^^^^^^^^^ source.hcl string.unquoted.heredoc.hcl meta.interpolation.hcl variable.other.member.hcl
 #                                              ^ source.hcl string.unquoted.heredoc.hcl meta.interpolation.hcl
 #                                               ^ source.hcl string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
@@ -207,7 +208,8 @@
 #                         ^ source.hcl string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
 #                          ^^^^^^^ source.hcl string.unquoted.heredoc.hcl meta.interpolation.hcl variable.other.member.hcl
 #                                 ^ source.hcl string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
-#                                  ^^ source.hcl string.unquoted.heredoc.hcl meta.interpolation.hcl
+#                                  ^ source.hcl string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.operator.splat.hcl
+#                                   ^ source.hcl string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
 #                                    ^^^^^^^^^^ source.hcl string.unquoted.heredoc.hcl meta.interpolation.hcl variable.other.member.hcl
 #                                              ^^ source.hcl string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.operator.template.right.trim.hcl
 #                                                ^ source.hcl string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
@@ -225,5 +227,61 @@
 >EOT
 #^^^^ source.hcl string.unquoted.heredoc.hcl keyword.control.heredoc.hcl
 >
+>attr = "abc${var.name.multi.step.addr}"
+#^^^^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl variable.declaration.hcl
+#     ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl variable.declaration.hcl
+#       ^ source.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#        ^^^ source.hcl string.quoted.double.hcl
+#           ^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
+#             ^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl variable.other.readwrite.hcl
+#                ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#                 ^^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
+#                     ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#                      ^^^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
+#                           ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#                            ^^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
+#                                ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#                                 ^^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
+#                                     ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
+#                                      ^ source.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
 >
+>attr = "abc${var.name.test.0.foo}"
+#^^^^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl variable.declaration.hcl
+#     ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl variable.declaration.hcl
+#       ^ source.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#        ^^^ source.hcl string.quoted.double.hcl
+#           ^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
+#             ^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl variable.other.readwrite.hcl
+#                ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#                 ^^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
+#                     ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#                      ^^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
+#                          ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#                           ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl constant.numeric.integer.hcl
+#                            ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#                             ^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
+#                                ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
+#                                 ^ source.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+>
+>attr = "abc${var.name.test.0}"
+#^^^^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl variable.declaration.hcl
+#     ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl variable.declaration.hcl
+#       ^ source.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#        ^^^ source.hcl string.quoted.double.hcl
+#           ^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
+#             ^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl variable.other.readwrite.hcl
+#                ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#                 ^^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
+#                     ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#                      ^^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
+#                          ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#                           ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl constant.numeric.integer.hcl
+#                            ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
+#                             ^ source.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
 >

--- a/tests/snapshot/hcl/expressions_strings.hcl.snap
+++ b/tests/snapshot/hcl/expressions_strings.hcl.snap
@@ -1,26 +1,42 @@
->"hello"
-#^ source.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
-# ^^^^^ source.hcl string.quoted.double.hcl
-#      ^ source.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+>attr = "hello"
+#^^^^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl variable.declaration.hcl
+#     ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl variable.declaration.hcl
+#       ^ source.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#        ^^^^^ source.hcl string.quoted.double.hcl
+#             ^ source.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
 >
->"\n\r\t\"\\"
-#^ source.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
-# ^^ source.hcl string.quoted.double.hcl constant.character.escape.hcl
-#   ^^ source.hcl string.quoted.double.hcl constant.character.escape.hcl
-#     ^^ source.hcl string.quoted.double.hcl constant.character.escape.hcl
-#       ^^ source.hcl string.quoted.double.hcl constant.character.escape.hcl
-#         ^^ source.hcl string.quoted.double.hcl constant.character.escape.hcl
-#           ^ source.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+>attr = "\n\r\t\"\\"
+#^^^^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl variable.declaration.hcl
+#     ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl variable.declaration.hcl
+#       ^ source.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#        ^^ source.hcl string.quoted.double.hcl constant.character.escape.hcl
+#          ^^ source.hcl string.quoted.double.hcl constant.character.escape.hcl
+#            ^^ source.hcl string.quoted.double.hcl constant.character.escape.hcl
+#              ^^ source.hcl string.quoted.double.hcl constant.character.escape.hcl
+#                ^^ source.hcl string.quoted.double.hcl constant.character.escape.hcl
+#                  ^ source.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
 >
->"$${}"
-#^ source.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
-# ^^^^ source.hcl string.quoted.double.hcl
-#     ^ source.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+>attr = "$${}"
+#^^^^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl variable.declaration.hcl
+#     ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl variable.declaration.hcl
+#       ^ source.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#        ^^^^ source.hcl string.quoted.double.hcl
+#            ^ source.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
 >
->"%%{}"
-#^ source.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
-# ^^^^ source.hcl string.quoted.double.hcl
-#     ^ source.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+>attr = "%%{}"
+#^^^^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl variable.declaration.hcl
+#     ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl variable.declaration.hcl
+#       ^ source.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#        ^^^^ source.hcl string.quoted.double.hcl
+#            ^ source.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
 >
 >thing = <<EOT
 #^^^^^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
@@ -78,56 +94,68 @@
 >}
 #^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
 >
->"Hello, ${var.name}!"
-#^ source.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
-# ^^^^^^^ source.hcl string.quoted.double.hcl
-#        ^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
-#          ^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl variable.other.readwrite.hcl
-#             ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
-#              ^^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
-#                  ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
-#                   ^ source.hcl string.quoted.double.hcl
-#                    ^ source.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+>attr = "Hello, ${var.name}!"
+#^^^^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl variable.declaration.hcl
+#     ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl variable.declaration.hcl
+#       ^ source.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#        ^^^^^^^ source.hcl string.quoted.double.hcl
+#               ^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
+#                 ^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl variable.other.readwrite.hcl
+#                    ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#                     ^^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
+#                         ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
+#                          ^ source.hcl string.quoted.double.hcl
+#                           ^ source.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
 >
->"Hello, %{ if var.name != "" }${var.name}%{ else }unnamed%{ endif }!"
-#^ source.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
-# ^^^^^^^ source.hcl string.quoted.double.hcl
-#        ^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
-#          ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl
-#           ^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.control.hcl
-#             ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl
-#              ^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl variable.other.readwrite.hcl
-#                 ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
-#                  ^^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
-#                      ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl
-#                       ^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.operator.hcl
-#                         ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl
-#                          ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
-#                           ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
-#                            ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl
-#                             ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
-#                              ^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
-#                                ^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl variable.other.readwrite.hcl
-#                                   ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
-#                                    ^^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
-#                                        ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
-#                                         ^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
-#                                           ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl
-#                                            ^^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.control.hcl
-#                                                ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl
-#                                                 ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
-#                                                  ^^^^^^^ source.hcl string.quoted.double.hcl
-#                                                         ^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
-#                                                           ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl
-#                                                            ^^^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.control.hcl
-#                                                                 ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl
-#                                                                  ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
-#                                                                   ^ source.hcl string.quoted.double.hcl
-#                                                                    ^ source.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+>attr = "Hello, %{ if var.name != "" }${var.name}%{ else }unnamed%{ endif }!"
+#^^^^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl variable.declaration.hcl
+#     ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl variable.declaration.hcl
+#       ^ source.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#        ^^^^^^^ source.hcl string.quoted.double.hcl
+#               ^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
+#                 ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl
+#                  ^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.control.hcl
+#                    ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl
+#                     ^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl variable.other.readwrite.hcl
+#                        ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#                         ^^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
+#                             ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl
+#                              ^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.operator.hcl
+#                                ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl
+#                                 ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                                  ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                                   ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl
+#                                    ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
+#                                     ^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
+#                                       ^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl variable.other.readwrite.hcl
+#                                          ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#                                           ^^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
+#                                               ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
+#                                                ^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
+#                                                  ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl
+#                                                   ^^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.control.hcl
+#                                                       ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl
+#                                                        ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
+#                                                         ^^^^^^^ source.hcl string.quoted.double.hcl
+#                                                                ^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
+#                                                                  ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl
+#                                                                   ^^^^^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.control.hcl
+#                                                                        ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl
+#                                                                         ^ source.hcl string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
+#                                                                          ^ source.hcl string.quoted.double.hcl
+#                                                                           ^ source.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
 >
-><<EOT
-#^^ source.hcl string.unquoted.heredoc.hcl keyword.operator.heredoc.hcl
-#  ^^^ source.hcl string.unquoted.heredoc.hcl keyword.control.heredoc.hcl
+>attr = <<EOT
+#^^^^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl variable.declaration.hcl
+#     ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl variable.declaration.hcl
+#       ^^ source.hcl string.unquoted.heredoc.hcl keyword.operator.heredoc.hcl
+#         ^^^ source.hcl string.unquoted.heredoc.hcl keyword.control.heredoc.hcl
 >%{ for ip in aws_instance.example.*.private_ip }
 #^^ source.hcl string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
 #  ^ source.hcl string.unquoted.heredoc.hcl meta.interpolation.hcl
@@ -159,9 +187,13 @@
 >EOT
 #^^^^ source.hcl string.unquoted.heredoc.hcl keyword.control.heredoc.hcl
 >
-><<EOT
-#^^ source.hcl string.unquoted.heredoc.hcl keyword.operator.heredoc.hcl
-#  ^^^ source.hcl string.unquoted.heredoc.hcl keyword.control.heredoc.hcl
+>attr = <<EOT
+#^^^^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl variable.declaration.hcl
+#     ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl variable.declaration.hcl
+#       ^^ source.hcl string.unquoted.heredoc.hcl keyword.operator.heredoc.hcl
+#         ^^^ source.hcl string.unquoted.heredoc.hcl keyword.control.heredoc.hcl
 >%{ for ip in aws_instance.example.*.private_ip ~}
 #^^ source.hcl string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
 #  ^ source.hcl string.unquoted.heredoc.hcl meta.interpolation.hcl

--- a/tests/snapshot/hcl/expressions_traversals.hcl
+++ b/tests/snapshot/hcl/expressions_traversals.hcl
@@ -1,0 +1,30 @@
+attr = var.test
+attr = var.test42
+attr = var.test42test
+attr = var.test-test
+attr = var.test_test
+attr = traversal
+
+# numeric index
+attr = var.test[42]
+attr = var.test[42][32]
+attr = var.test[42].test
+
+# string index
+attr = var.test["key"]
+attr = var.test["key"]["two"]
+attr = var.test["key"].test
+
+# legacy numeric index
+attr = var.test.42
+attr = var.test.42.32
+attr = var.test.42.test
+
+# incomplete expression with trailing multiplication operator
+attr = var.list*
+
+# ensure this is multiplication and not splat
+attr = var.li*st
+
+# invalid attribute accessor
+attr = var.42test

--- a/tests/snapshot/hcl/expressions_traversals.hcl.snap
+++ b/tests/snapshot/hcl/expressions_traversals.hcl.snap
@@ -1,0 +1,217 @@
+>attr = var.test
+#^^^^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl variable.declaration.hcl
+#     ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl variable.declaration.hcl
+#       ^^^ source.hcl
+#          ^ source.hcl keyword.operator.accessor.hcl
+#           ^^^^ source.hcl variable.other.member.hcl
+>attr = var.test42
+#^^^^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl variable.declaration.hcl
+#     ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl variable.declaration.hcl
+#       ^^^ source.hcl
+#          ^ source.hcl keyword.operator.accessor.hcl
+#           ^^^^^^ source.hcl variable.other.member.hcl
+>attr = var.test42test
+#^^^^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl variable.declaration.hcl
+#     ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl variable.declaration.hcl
+#       ^^^ source.hcl
+#          ^ source.hcl keyword.operator.accessor.hcl
+#           ^^^^^^^^^^ source.hcl variable.other.member.hcl
+>attr = var.test-test
+#^^^^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl variable.declaration.hcl
+#     ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl variable.declaration.hcl
+#       ^^^ source.hcl
+#          ^ source.hcl keyword.operator.accessor.hcl
+#           ^^^^^^^^^ source.hcl variable.other.member.hcl
+>attr = var.test_test
+#^^^^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl variable.declaration.hcl
+#     ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl variable.declaration.hcl
+#       ^^^ source.hcl
+#          ^ source.hcl keyword.operator.accessor.hcl
+#           ^^^^^^^^^ source.hcl variable.other.member.hcl
+>attr = traversal
+#^^^^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl variable.declaration.hcl
+#     ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl variable.declaration.hcl
+#       ^^^^^^^^^^ source.hcl
+>
+># numeric index
+#^ source.hcl comment.line.number-sign.hcl punctuation.definition.comment.hcl
+# ^^^^^^^^^^^^^^ source.hcl comment.line.number-sign.hcl
+>attr = var.test[42]
+#^^^^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl variable.declaration.hcl
+#     ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl variable.declaration.hcl
+#       ^^^ source.hcl
+#          ^ source.hcl keyword.operator.accessor.hcl
+#           ^^^^ source.hcl variable.other.member.hcl
+#               ^ source.hcl punctuation.section.brackets.begin.hcl
+#                ^^ source.hcl constant.numeric.integer.hcl
+#                  ^ source.hcl punctuation.section.brackets.end.hcl
+>attr = var.test[42][32]
+#^^^^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl variable.declaration.hcl
+#     ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl variable.declaration.hcl
+#       ^^^ source.hcl
+#          ^ source.hcl keyword.operator.accessor.hcl
+#           ^^^^ source.hcl variable.other.member.hcl
+#               ^ source.hcl punctuation.section.brackets.begin.hcl
+#                ^^ source.hcl constant.numeric.integer.hcl
+#                  ^ source.hcl punctuation.section.brackets.end.hcl
+#                   ^ source.hcl punctuation.section.brackets.begin.hcl
+#                    ^^ source.hcl constant.numeric.integer.hcl
+#                      ^ source.hcl punctuation.section.brackets.end.hcl
+>attr = var.test[42].test
+#^^^^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl variable.declaration.hcl
+#     ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl variable.declaration.hcl
+#       ^^^ source.hcl
+#          ^ source.hcl keyword.operator.accessor.hcl
+#           ^^^^ source.hcl variable.other.member.hcl
+#               ^ source.hcl punctuation.section.brackets.begin.hcl
+#                ^^ source.hcl constant.numeric.integer.hcl
+#                  ^ source.hcl punctuation.section.brackets.end.hcl
+#                   ^ source.hcl keyword.operator.accessor.hcl
+#                    ^^^^ source.hcl variable.other.member.hcl
+>
+># string index
+#^ source.hcl comment.line.number-sign.hcl punctuation.definition.comment.hcl
+# ^^^^^^^^^^^^^ source.hcl comment.line.number-sign.hcl
+>attr = var.test["key"]
+#^^^^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl variable.declaration.hcl
+#     ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl variable.declaration.hcl
+#       ^^^ source.hcl
+#          ^ source.hcl keyword.operator.accessor.hcl
+#           ^^^^ source.hcl variable.other.member.hcl
+#               ^ source.hcl punctuation.section.brackets.begin.hcl
+#                ^ source.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                 ^^^ source.hcl string.quoted.double.hcl
+#                    ^ source.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                     ^ source.hcl punctuation.section.brackets.end.hcl
+>attr = var.test["key"]["two"]
+#^^^^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl variable.declaration.hcl
+#     ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl variable.declaration.hcl
+#       ^^^ source.hcl
+#          ^ source.hcl keyword.operator.accessor.hcl
+#           ^^^^ source.hcl variable.other.member.hcl
+#               ^ source.hcl punctuation.section.brackets.begin.hcl
+#                ^ source.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                 ^^^ source.hcl string.quoted.double.hcl
+#                    ^ source.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                     ^ source.hcl punctuation.section.brackets.end.hcl
+#                      ^ source.hcl punctuation.section.brackets.begin.hcl
+#                       ^ source.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                        ^^^ source.hcl string.quoted.double.hcl
+#                           ^ source.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                            ^ source.hcl punctuation.section.brackets.end.hcl
+>attr = var.test["key"].test
+#^^^^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl variable.declaration.hcl
+#     ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl variable.declaration.hcl
+#       ^^^ source.hcl
+#          ^ source.hcl keyword.operator.accessor.hcl
+#           ^^^^ source.hcl variable.other.member.hcl
+#               ^ source.hcl punctuation.section.brackets.begin.hcl
+#                ^ source.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                 ^^^ source.hcl string.quoted.double.hcl
+#                    ^ source.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                     ^ source.hcl punctuation.section.brackets.end.hcl
+#                      ^ source.hcl keyword.operator.accessor.hcl
+#                       ^^^^ source.hcl variable.other.member.hcl
+>
+># legacy numeric index
+#^ source.hcl comment.line.number-sign.hcl punctuation.definition.comment.hcl
+# ^^^^^^^^^^^^^^^^^^^^^ source.hcl comment.line.number-sign.hcl
+>attr = var.test.42
+#^^^^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl variable.declaration.hcl
+#     ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl variable.declaration.hcl
+#       ^^^ source.hcl
+#          ^ source.hcl keyword.operator.accessor.hcl
+#           ^^^^ source.hcl variable.other.member.hcl
+#               ^ source.hcl keyword.operator.accessor.hcl
+#                ^^ source.hcl constant.numeric.integer.hcl
+>attr = var.test.42.32
+#^^^^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl variable.declaration.hcl
+#     ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl variable.declaration.hcl
+#       ^^^ source.hcl
+#          ^ source.hcl keyword.operator.accessor.hcl
+#           ^^^^ source.hcl variable.other.member.hcl
+#               ^ source.hcl keyword.operator.accessor.hcl
+#                ^^ source.hcl constant.numeric.integer.hcl
+#                  ^ source.hcl keyword.operator.accessor.hcl
+#                   ^^ source.hcl constant.numeric.integer.hcl
+>attr = var.test.42.test
+#^^^^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl variable.declaration.hcl
+#     ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl variable.declaration.hcl
+#       ^^^ source.hcl
+#          ^ source.hcl keyword.operator.accessor.hcl
+#           ^^^^ source.hcl variable.other.member.hcl
+#               ^ source.hcl keyword.operator.accessor.hcl
+#                ^^ source.hcl constant.numeric.integer.hcl
+#                  ^ source.hcl keyword.operator.accessor.hcl
+#                   ^^^^ source.hcl variable.other.member.hcl
+>
+># incomplete expression with trailing multiplication operator
+#^ source.hcl comment.line.number-sign.hcl punctuation.definition.comment.hcl
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl comment.line.number-sign.hcl
+>attr = var.list*
+#^^^^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl variable.declaration.hcl
+#     ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl variable.declaration.hcl
+#       ^^^ source.hcl
+#          ^ source.hcl keyword.operator.accessor.hcl
+#           ^^^^ source.hcl variable.other.member.hcl
+#               ^ source.hcl keyword.operator.arithmetic.hcl
+>
+># ensure this is multiplication and not splat
+#^ source.hcl comment.line.number-sign.hcl punctuation.definition.comment.hcl
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl comment.line.number-sign.hcl
+>attr = var.li*st
+#^^^^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl variable.declaration.hcl
+#     ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl variable.declaration.hcl
+#       ^^^ source.hcl
+#          ^ source.hcl keyword.operator.accessor.hcl
+#           ^^ source.hcl variable.other.member.hcl
+#             ^ source.hcl keyword.operator.arithmetic.hcl
+#              ^^^ source.hcl
+>
+># invalid attribute accessor
+#^ source.hcl comment.line.number-sign.hcl punctuation.definition.comment.hcl
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl comment.line.number-sign.hcl
+>attr = var.42test
+#^^^^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl variable.declaration.hcl
+#     ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl variable.declaration.hcl
+#       ^^^ source.hcl
+#          ^ source.hcl keyword.operator.accessor.hcl
+#           ^^ source.hcl constant.numeric.integer.hcl
+#             ^^^^^ source.hcl
+>

--- a/tests/snapshot/hcl/variables_local.hcl.snap
+++ b/tests/snapshot/hcl/variables_local.hcl.snap
@@ -43,14 +43,16 @@
 #                                    ^ source.hcl meta.block.hcl meta.function-call.hcl keyword.operator.accessor.hcl
 #                                     ^^^^ source.hcl meta.block.hcl meta.function-call.hcl variable.other.member.hcl
 #                                         ^ source.hcl meta.block.hcl meta.function-call.hcl keyword.operator.accessor.hcl
-#                                          ^^ source.hcl meta.block.hcl meta.function-call.hcl
+#                                          ^ source.hcl meta.block.hcl meta.function-call.hcl keyword.operator.splat.hcl
+#                                           ^ source.hcl meta.block.hcl meta.function-call.hcl keyword.operator.accessor.hcl
 #                                            ^^ source.hcl meta.block.hcl meta.function-call.hcl variable.other.member.hcl
 #                                              ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.separator.hcl
 #                                               ^^^^^^^^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl
 #                                                            ^ source.hcl meta.block.hcl meta.function-call.hcl keyword.operator.accessor.hcl
 #                                                             ^^^^^ source.hcl meta.block.hcl meta.function-call.hcl variable.other.member.hcl
 #                                                                  ^ source.hcl meta.block.hcl meta.function-call.hcl keyword.operator.accessor.hcl
-#                                                                   ^^ source.hcl meta.block.hcl meta.function-call.hcl
+#                                                                   ^ source.hcl meta.block.hcl meta.function-call.hcl keyword.operator.splat.hcl
+#                                                                    ^ source.hcl meta.block.hcl meta.function-call.hcl keyword.operator.accessor.hcl
 #                                                                     ^^ source.hcl meta.block.hcl meta.function-call.hcl variable.other.member.hcl
 #                                                                       ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
 >}

--- a/tests/snapshot/terraform/expressions_splat.tf
+++ b/tests/snapshot/terraform/expressions_splat.tf
@@ -1,5 +1,5 @@
-[for o in var.list : o.id]
+attr = [for o in var.list : o.id]
 
-var.list[*].id
+attr = var.list[*].id
 
-var.list[*].interfaces[0].name
+attr = var.list[*].interfaces[0].name

--- a/tests/snapshot/terraform/expressions_splat.tf
+++ b/tests/snapshot/terraform/expressions_splat.tf
@@ -3,3 +3,11 @@ attr = [for o in var.list : o.id]
 attr = var.list[*].id
 
 attr = var.list[*].interfaces[0].name
+
+attr = var.list.*.id
+
+attr = "${var.list.*.id}"
+
+attr = "${var.list.*}"
+
+attr = var.list.*

--- a/tests/snapshot/terraform/expressions_splat.tf.snap
+++ b/tests/snapshot/terraform/expressions_splat.tf.snap
@@ -1,44 +1,56 @@
->[for o in var.list : o.id]
-#^ source.hcl.terraform punctuation.section.brackets.begin.hcl
-# ^^^ source.hcl.terraform keyword.control.hcl
-#    ^ source.hcl.terraform
-#     ^ source.hcl.terraform variable.other.readwrite.hcl
-#      ^ source.hcl.terraform
-#       ^^ source.hcl.terraform keyword.operator.word.hcl
-#         ^ source.hcl.terraform
-#          ^^^ source.hcl.terraform variable.other.readwrite.terraform
-#             ^ source.hcl.terraform keyword.operator.accessor.hcl
-#              ^^^^ source.hcl.terraform variable.other.member.hcl
-#                  ^ source.hcl.terraform
-#                   ^ source.hcl.terraform keyword.operator.hcl
-#                    ^ source.hcl.terraform
-#                     ^ source.hcl.terraform variable.other.readwrite.hcl
-#                      ^ source.hcl.terraform keyword.operator.accessor.hcl
-#                       ^^ source.hcl.terraform variable.other.member.hcl
-#                         ^ source.hcl.terraform punctuation.section.brackets.end.hcl
+>attr = [for o in var.list : o.id]
+#^^^^ source.hcl.terraform variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl.terraform variable.declaration.hcl
+#     ^ source.hcl.terraform variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl.terraform variable.declaration.hcl
+#       ^ source.hcl.terraform punctuation.section.brackets.begin.hcl
+#        ^^^ source.hcl.terraform keyword.control.hcl
+#           ^ source.hcl.terraform
+#            ^ source.hcl.terraform variable.other.readwrite.hcl
+#             ^ source.hcl.terraform
+#              ^^ source.hcl.terraform keyword.operator.word.hcl
+#                ^ source.hcl.terraform
+#                 ^^^ source.hcl.terraform variable.other.readwrite.terraform
+#                    ^ source.hcl.terraform keyword.operator.accessor.hcl
+#                     ^^^^ source.hcl.terraform variable.other.member.hcl
+#                         ^ source.hcl.terraform
+#                          ^ source.hcl.terraform keyword.operator.hcl
+#                           ^ source.hcl.terraform
+#                            ^ source.hcl.terraform variable.other.readwrite.hcl
+#                             ^ source.hcl.terraform keyword.operator.accessor.hcl
+#                              ^^ source.hcl.terraform variable.other.member.hcl
+#                                ^ source.hcl.terraform punctuation.section.brackets.end.hcl
 >
->var.list[*].id
-#^^^ source.hcl.terraform variable.other.readwrite.terraform
-#   ^ source.hcl.terraform keyword.operator.accessor.hcl
-#    ^^^^ source.hcl.terraform variable.other.member.hcl
-#        ^ source.hcl.terraform
-#         ^ source.hcl.terraform keyword.operator.splat.hcl
-#          ^ source.hcl.terraform
-#           ^ source.hcl.terraform keyword.operator.accessor.hcl
-#            ^^ source.hcl.terraform variable.other.member.hcl
+>attr = var.list[*].id
+#^^^^ source.hcl.terraform variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl.terraform variable.declaration.hcl
+#     ^ source.hcl.terraform variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl.terraform variable.declaration.hcl
+#       ^^^ source.hcl.terraform variable.other.readwrite.terraform
+#          ^ source.hcl.terraform keyword.operator.accessor.hcl
+#           ^^^^ source.hcl.terraform variable.other.member.hcl
+#               ^ source.hcl.terraform
+#                ^ source.hcl.terraform keyword.operator.splat.hcl
+#                 ^ source.hcl.terraform
+#                  ^ source.hcl.terraform keyword.operator.accessor.hcl
+#                   ^^ source.hcl.terraform variable.other.member.hcl
 >
->var.list[*].interfaces[0].name
-#^^^ source.hcl.terraform variable.other.readwrite.terraform
-#   ^ source.hcl.terraform keyword.operator.accessor.hcl
-#    ^^^^ source.hcl.terraform variable.other.member.hcl
-#        ^ source.hcl.terraform
-#         ^ source.hcl.terraform keyword.operator.splat.hcl
-#          ^ source.hcl.terraform
-#           ^ source.hcl.terraform keyword.operator.accessor.hcl
-#            ^^^^^^^^^^ source.hcl.terraform variable.other.member.hcl
-#                      ^ source.hcl.terraform
-#                       ^ source.hcl.terraform constant.numeric.integer.hcl
-#                        ^ source.hcl.terraform
-#                         ^ source.hcl.terraform keyword.operator.accessor.hcl
-#                          ^^^^ source.hcl.terraform variable.other.member.hcl
+>attr = var.list[*].interfaces[0].name
+#^^^^ source.hcl.terraform variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl.terraform variable.declaration.hcl
+#     ^ source.hcl.terraform variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl.terraform variable.declaration.hcl
+#       ^^^ source.hcl.terraform variable.other.readwrite.terraform
+#          ^ source.hcl.terraform keyword.operator.accessor.hcl
+#           ^^^^ source.hcl.terraform variable.other.member.hcl
+#               ^ source.hcl.terraform
+#                ^ source.hcl.terraform keyword.operator.splat.hcl
+#                 ^ source.hcl.terraform
+#                  ^ source.hcl.terraform keyword.operator.accessor.hcl
+#                   ^^^^^^^^^^ source.hcl.terraform variable.other.member.hcl
+#                             ^ source.hcl.terraform
+#                              ^ source.hcl.terraform constant.numeric.integer.hcl
+#                               ^ source.hcl.terraform
+#                                ^ source.hcl.terraform keyword.operator.accessor.hcl
+#                                 ^^^^ source.hcl.terraform variable.other.member.hcl
 >

--- a/tests/snapshot/terraform/expressions_splat.tf.snap
+++ b/tests/snapshot/terraform/expressions_splat.tf.snap
@@ -29,9 +29,9 @@
 #       ^^^ source.hcl.terraform variable.other.readwrite.terraform
 #          ^ source.hcl.terraform keyword.operator.accessor.hcl
 #           ^^^^ source.hcl.terraform variable.other.member.hcl
-#               ^ source.hcl.terraform
+#               ^ source.hcl.terraform punctuation.section.brackets.begin.hcl
 #                ^ source.hcl.terraform keyword.operator.splat.hcl
-#                 ^ source.hcl.terraform
+#                 ^ source.hcl.terraform punctuation.section.brackets.end.hcl
 #                  ^ source.hcl.terraform keyword.operator.accessor.hcl
 #                   ^^ source.hcl.terraform variable.other.member.hcl
 >
@@ -43,14 +43,70 @@
 #       ^^^ source.hcl.terraform variable.other.readwrite.terraform
 #          ^ source.hcl.terraform keyword.operator.accessor.hcl
 #           ^^^^ source.hcl.terraform variable.other.member.hcl
-#               ^ source.hcl.terraform
+#               ^ source.hcl.terraform punctuation.section.brackets.begin.hcl
 #                ^ source.hcl.terraform keyword.operator.splat.hcl
-#                 ^ source.hcl.terraform
+#                 ^ source.hcl.terraform punctuation.section.brackets.end.hcl
 #                  ^ source.hcl.terraform keyword.operator.accessor.hcl
 #                   ^^^^^^^^^^ source.hcl.terraform variable.other.member.hcl
-#                             ^ source.hcl.terraform
+#                             ^ source.hcl.terraform punctuation.section.brackets.begin.hcl
 #                              ^ source.hcl.terraform constant.numeric.integer.hcl
-#                               ^ source.hcl.terraform
+#                               ^ source.hcl.terraform punctuation.section.brackets.end.hcl
 #                                ^ source.hcl.terraform keyword.operator.accessor.hcl
 #                                 ^^^^ source.hcl.terraform variable.other.member.hcl
+>
+>attr = var.list.*.id
+#^^^^ source.hcl.terraform variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl.terraform variable.declaration.hcl
+#     ^ source.hcl.terraform variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl.terraform variable.declaration.hcl
+#       ^^^ source.hcl.terraform variable.other.readwrite.terraform
+#          ^ source.hcl.terraform keyword.operator.accessor.hcl
+#           ^^^^ source.hcl.terraform variable.other.member.hcl
+#               ^ source.hcl.terraform keyword.operator.accessor.hcl
+#                ^ source.hcl.terraform keyword.operator.splat.hcl
+#                 ^ source.hcl.terraform keyword.operator.accessor.hcl
+#                  ^^ source.hcl.terraform variable.other.member.hcl
+>
+>attr = "${var.list.*.id}"
+#^^^^ source.hcl.terraform variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl.terraform variable.declaration.hcl
+#     ^ source.hcl.terraform variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl.terraform variable.declaration.hcl
+#       ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#        ^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
+#          ^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.readwrite.terraform
+#             ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#              ^^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
+#                  ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#                   ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.operator.splat.hcl
+#                    ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#                     ^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
+#                       ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
+#                        ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.end.hcl
+>
+>attr = "${var.list.*}"
+#^^^^ source.hcl.terraform variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl.terraform variable.declaration.hcl
+#     ^ source.hcl.terraform variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl.terraform variable.declaration.hcl
+#       ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#        ^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
+#          ^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.readwrite.terraform
+#             ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#              ^^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
+#                  ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#                   ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.operator.splat.hcl
+#                    ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
+#                     ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.end.hcl
+>
+>attr = var.list.*
+#^^^^ source.hcl.terraform variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl.terraform variable.declaration.hcl
+#     ^ source.hcl.terraform variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl.terraform variable.declaration.hcl
+#       ^^^ source.hcl.terraform variable.other.readwrite.terraform
+#          ^ source.hcl.terraform keyword.operator.accessor.hcl
+#           ^^^^ source.hcl.terraform variable.other.member.hcl
+#               ^ source.hcl.terraform keyword.operator.accessor.hcl
+#                ^ source.hcl.terraform keyword.operator.splat.hcl
 >

--- a/tests/snapshot/terraform/expressions_strings.tf
+++ b/tests/snapshot/terraform/expressions_strings.tf
@@ -1,10 +1,10 @@
-"hello"
+attr = "hello"
 
-"\n\r\t\"\\"
+attr = "\n\r\t\"\\"
 
-"$${}"
+attr = "$${}"
 
-"%%{}"
+attr = "%%{}"
 
 thing = <<EOT
 hello
@@ -25,20 +25,18 @@ block {
   EOT
 }
 
-"Hello, ${var.name}${var.name}!"
+attr = "Hello, ${var.name}${var.name}!"
 
-"Hello, %{ if var.name != "" }${var.name}%{ else }unnamed%{ endif }!"
+attr = "Hello, %{ if var.name != "" }${var.name}%{ else }unnamed%{ endif }!"
 
-<<EOT
+attr = <<EOT
 %{ for ip in aws_instance.example.*.private_ip }
 server ${ip}
 %{ endfor }
 EOT
 
-<<EOT
+attr = <<EOT
 %{ for ip in aws_instance.example.*.private_ip ~}
 server ${ip}
 %{ endfor ~}
 EOT
-
-

--- a/tests/snapshot/terraform/expressions_strings.tf
+++ b/tests/snapshot/terraform/expressions_strings.tf
@@ -40,3 +40,9 @@ attr = <<EOT
 server ${ip}
 %{ endfor ~}
 EOT
+
+attr = "abc${var.name.multi.step.addr}"
+
+attr = "abc${var.name.test.0.foo}"
+
+attr = "abc${var.name.test.0}"

--- a/tests/snapshot/terraform/expressions_strings.tf.snap
+++ b/tests/snapshot/terraform/expressions_strings.tf.snap
@@ -1,26 +1,42 @@
->"hello"
-#^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.begin.hcl
-# ^^^^^ source.hcl.terraform string.quoted.double.hcl
-#      ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.end.hcl
+>attr = "hello"
+#^^^^ source.hcl.terraform variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl.terraform variable.declaration.hcl
+#     ^ source.hcl.terraform variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl.terraform variable.declaration.hcl
+#       ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#        ^^^^^ source.hcl.terraform string.quoted.double.hcl
+#             ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.end.hcl
 >
->"\n\r\t\"\\"
-#^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.begin.hcl
-# ^^ source.hcl.terraform string.quoted.double.hcl constant.character.escape.hcl
-#   ^^ source.hcl.terraform string.quoted.double.hcl constant.character.escape.hcl
-#     ^^ source.hcl.terraform string.quoted.double.hcl constant.character.escape.hcl
-#       ^^ source.hcl.terraform string.quoted.double.hcl constant.character.escape.hcl
-#         ^^ source.hcl.terraform string.quoted.double.hcl constant.character.escape.hcl
-#           ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.end.hcl
+>attr = "\n\r\t\"\\"
+#^^^^ source.hcl.terraform variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl.terraform variable.declaration.hcl
+#     ^ source.hcl.terraform variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl.terraform variable.declaration.hcl
+#       ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#        ^^ source.hcl.terraform string.quoted.double.hcl constant.character.escape.hcl
+#          ^^ source.hcl.terraform string.quoted.double.hcl constant.character.escape.hcl
+#            ^^ source.hcl.terraform string.quoted.double.hcl constant.character.escape.hcl
+#              ^^ source.hcl.terraform string.quoted.double.hcl constant.character.escape.hcl
+#                ^^ source.hcl.terraform string.quoted.double.hcl constant.character.escape.hcl
+#                  ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.end.hcl
 >
->"$${}"
-#^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.begin.hcl
-# ^^^^ source.hcl.terraform string.quoted.double.hcl
-#     ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.end.hcl
+>attr = "$${}"
+#^^^^ source.hcl.terraform variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl.terraform variable.declaration.hcl
+#     ^ source.hcl.terraform variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl.terraform variable.declaration.hcl
+#       ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#        ^^^^ source.hcl.terraform string.quoted.double.hcl
+#            ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.end.hcl
 >
->"%%{}"
-#^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.begin.hcl
-# ^^^^ source.hcl.terraform string.quoted.double.hcl
-#     ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.end.hcl
+>attr = "%%{}"
+#^^^^ source.hcl.terraform variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl.terraform variable.declaration.hcl
+#     ^ source.hcl.terraform variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl.terraform variable.declaration.hcl
+#       ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#        ^^^^ source.hcl.terraform string.quoted.double.hcl
+#            ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.end.hcl
 >
 >thing = <<EOT
 #^^^^^ source.hcl.terraform variable.declaration.hcl variable.other.readwrite.hcl
@@ -78,61 +94,73 @@
 >}
 #^ source.hcl.terraform meta.block.hcl punctuation.section.block.end.hcl
 >
->"Hello, ${var.name}${var.name}!"
-#^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.begin.hcl
-# ^^^^^^^ source.hcl.terraform string.quoted.double.hcl
-#        ^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
-#          ^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.readwrite.terraform
-#             ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
-#              ^^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
-#                  ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
-#                   ^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
+>attr = "Hello, ${var.name}${var.name}!"
+#^^^^ source.hcl.terraform variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl.terraform variable.declaration.hcl
+#     ^ source.hcl.terraform variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl.terraform variable.declaration.hcl
+#       ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#        ^^^^^^^ source.hcl.terraform string.quoted.double.hcl
+#               ^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
+#                 ^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.readwrite.terraform
+#                    ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#                     ^^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
+#                         ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
+#                          ^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
+#                            ^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.readwrite.terraform
+#                               ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#                                ^^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
+#                                    ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
+#                                     ^ source.hcl.terraform string.quoted.double.hcl
+#                                      ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.end.hcl
+>
+>attr = "Hello, %{ if var.name != "" }${var.name}%{ else }unnamed%{ endif }!"
+#^^^^ source.hcl.terraform variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl.terraform variable.declaration.hcl
+#     ^ source.hcl.terraform variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl.terraform variable.declaration.hcl
+#       ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#        ^^^^^^^ source.hcl.terraform string.quoted.double.hcl
+#               ^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
+#                 ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl
+#                  ^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.control.hcl
+#                    ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl
 #                     ^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.readwrite.terraform
 #                        ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
 #                         ^^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
-#                             ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
-#                              ^ source.hcl.terraform string.quoted.double.hcl
-#                               ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                             ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl
+#                              ^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.operator.hcl
+#                                ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl
+#                                 ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                                  ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                                   ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl
+#                                    ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
+#                                     ^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
+#                                       ^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.readwrite.terraform
+#                                          ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#                                           ^^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
+#                                               ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
+#                                                ^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
+#                                                  ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl
+#                                                   ^^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.control.hcl
+#                                                       ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl
+#                                                        ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
+#                                                         ^^^^^^^ source.hcl.terraform string.quoted.double.hcl
+#                                                                ^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
+#                                                                  ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl
+#                                                                   ^^^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.control.hcl
+#                                                                        ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl
+#                                                                         ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
+#                                                                          ^ source.hcl.terraform string.quoted.double.hcl
+#                                                                           ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.end.hcl
 >
->"Hello, %{ if var.name != "" }${var.name}%{ else }unnamed%{ endif }!"
-#^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.begin.hcl
-# ^^^^^^^ source.hcl.terraform string.quoted.double.hcl
-#        ^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
-#          ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl
-#           ^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.control.hcl
-#             ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl
-#              ^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.readwrite.terraform
-#                 ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
-#                  ^^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
-#                      ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl
-#                       ^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.operator.hcl
-#                         ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl
-#                          ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
-#                           ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
-#                            ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl
-#                             ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
-#                              ^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
-#                                ^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.readwrite.terraform
-#                                   ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
-#                                    ^^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
-#                                        ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
-#                                         ^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
-#                                           ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl
-#                                            ^^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.control.hcl
-#                                                ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl
-#                                                 ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
-#                                                  ^^^^^^^ source.hcl.terraform string.quoted.double.hcl
-#                                                         ^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
-#                                                           ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl
-#                                                            ^^^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.control.hcl
-#                                                                 ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl
-#                                                                  ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
-#                                                                   ^ source.hcl.terraform string.quoted.double.hcl
-#                                                                    ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.end.hcl
->
-><<EOT
-#^^ source.hcl.terraform string.unquoted.heredoc.hcl keyword.operator.heredoc.hcl
-#  ^^^ source.hcl.terraform string.unquoted.heredoc.hcl keyword.control.heredoc.hcl
+>attr = <<EOT
+#^^^^ source.hcl.terraform variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl.terraform variable.declaration.hcl
+#     ^ source.hcl.terraform variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl.terraform variable.declaration.hcl
+#       ^^ source.hcl.terraform string.unquoted.heredoc.hcl keyword.operator.heredoc.hcl
+#         ^^^ source.hcl.terraform string.unquoted.heredoc.hcl keyword.control.heredoc.hcl
 >%{ for ip in aws_instance.example.*.private_ip }
 #^^ source.hcl.terraform string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
 #  ^ source.hcl.terraform string.unquoted.heredoc.hcl meta.interpolation.hcl
@@ -164,9 +192,13 @@
 >EOT
 #^^^^ source.hcl.terraform string.unquoted.heredoc.hcl keyword.control.heredoc.hcl
 >
-><<EOT
-#^^ source.hcl.terraform string.unquoted.heredoc.hcl keyword.operator.heredoc.hcl
-#  ^^^ source.hcl.terraform string.unquoted.heredoc.hcl keyword.control.heredoc.hcl
+>attr = <<EOT
+#^^^^ source.hcl.terraform variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl.terraform variable.declaration.hcl
+#     ^ source.hcl.terraform variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl.terraform variable.declaration.hcl
+#       ^^ source.hcl.terraform string.unquoted.heredoc.hcl keyword.operator.heredoc.hcl
+#         ^^^ source.hcl.terraform string.unquoted.heredoc.hcl keyword.control.heredoc.hcl
 >%{ for ip in aws_instance.example.*.private_ip ~}
 #^^ source.hcl.terraform string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
 #  ^ source.hcl.terraform string.unquoted.heredoc.hcl meta.interpolation.hcl
@@ -197,6 +229,4 @@
 #           ^ source.hcl.terraform string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
 >EOT
 #^^^^ source.hcl.terraform string.unquoted.heredoc.hcl keyword.control.heredoc.hcl
->
->
 >

--- a/tests/snapshot/terraform/expressions_strings.tf.snap
+++ b/tests/snapshot/terraform/expressions_strings.tf.snap
@@ -174,7 +174,8 @@
 #                         ^ source.hcl.terraform string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
 #                          ^^^^^^^ source.hcl.terraform string.unquoted.heredoc.hcl meta.interpolation.hcl variable.other.member.hcl
 #                                 ^ source.hcl.terraform string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
-#                                  ^^ source.hcl.terraform string.unquoted.heredoc.hcl meta.interpolation.hcl
+#                                  ^ source.hcl.terraform string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.operator.splat.hcl
+#                                   ^ source.hcl.terraform string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
 #                                    ^^^^^^^^^^ source.hcl.terraform string.unquoted.heredoc.hcl meta.interpolation.hcl variable.other.member.hcl
 #                                              ^ source.hcl.terraform string.unquoted.heredoc.hcl meta.interpolation.hcl
 #                                               ^ source.hcl.terraform string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
@@ -212,7 +213,8 @@
 #                         ^ source.hcl.terraform string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
 #                          ^^^^^^^ source.hcl.terraform string.unquoted.heredoc.hcl meta.interpolation.hcl variable.other.member.hcl
 #                                 ^ source.hcl.terraform string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
-#                                  ^^ source.hcl.terraform string.unquoted.heredoc.hcl meta.interpolation.hcl
+#                                  ^ source.hcl.terraform string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.operator.splat.hcl
+#                                   ^ source.hcl.terraform string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
 #                                    ^^^^^^^^^^ source.hcl.terraform string.unquoted.heredoc.hcl meta.interpolation.hcl variable.other.member.hcl
 #                                              ^^ source.hcl.terraform string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.operator.template.right.trim.hcl
 #                                                ^ source.hcl.terraform string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
@@ -229,4 +231,62 @@
 #           ^ source.hcl.terraform string.unquoted.heredoc.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
 >EOT
 #^^^^ source.hcl.terraform string.unquoted.heredoc.hcl keyword.control.heredoc.hcl
+>
+>attr = "abc${var.name.multi.step.addr}"
+#^^^^ source.hcl.terraform variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl.terraform variable.declaration.hcl
+#     ^ source.hcl.terraform variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl.terraform variable.declaration.hcl
+#       ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#        ^^^ source.hcl.terraform string.quoted.double.hcl
+#           ^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
+#             ^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.readwrite.terraform
+#                ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#                 ^^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
+#                     ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#                      ^^^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
+#                           ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#                            ^^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
+#                                ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#                                 ^^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
+#                                     ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
+#                                      ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.end.hcl
+>
+>attr = "abc${var.name.test.0.foo}"
+#^^^^ source.hcl.terraform variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl.terraform variable.declaration.hcl
+#     ^ source.hcl.terraform variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl.terraform variable.declaration.hcl
+#       ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#        ^^^ source.hcl.terraform string.quoted.double.hcl
+#           ^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
+#             ^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.readwrite.terraform
+#                ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#                 ^^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
+#                     ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#                      ^^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
+#                          ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#                           ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl constant.numeric.integer.hcl
+#                            ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#                             ^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
+#                                ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
+#                                 ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.end.hcl
+>
+>attr = "abc${var.name.test.0}"
+#^^^^ source.hcl.terraform variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl.terraform variable.declaration.hcl
+#     ^ source.hcl.terraform variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl.terraform variable.declaration.hcl
+#       ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#        ^^^ source.hcl.terraform string.quoted.double.hcl
+#           ^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.begin.hcl
+#             ^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.readwrite.terraform
+#                ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#                 ^^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
+#                     ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#                      ^^^^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl variable.other.member.hcl
+#                          ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.operator.accessor.hcl
+#                           ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl constant.numeric.integer.hcl
+#                            ^ source.hcl.terraform string.quoted.double.hcl meta.interpolation.hcl keyword.other.interpolation.end.hcl
+#                             ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.end.hcl
 >

--- a/tests/snapshot/terraform/expressions_traversals.hcl
+++ b/tests/snapshot/terraform/expressions_traversals.hcl
@@ -1,0 +1,30 @@
+attr = var.test
+attr = var.test42
+attr = var.test42test
+attr = var.test-test
+attr = var.test_test
+attr = traversal
+
+# numeric index
+attr = var.test[42]
+attr = var.test[42][32]
+attr = var.test[42].test
+
+# string index
+attr = var.test["key"]
+attr = var.test["key"]["two"]
+attr = var.test["key"].test
+
+# legacy numeric index
+attr = var.test.42
+attr = var.test.42.32
+attr = var.test.42.test
+
+# incomplete expression with trailing multiplication operator
+attr = var.list*
+
+# ensure this is multiplication and not splat
+attr = var.li*st
+
+# invalid attribute accessor
+attr = var.42test

--- a/tests/snapshot/terraform/expressions_traversals.hcl.snap
+++ b/tests/snapshot/terraform/expressions_traversals.hcl.snap
@@ -1,0 +1,217 @@
+>attr = var.test
+#^^^^ source.hcl.terraform variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl.terraform variable.declaration.hcl
+#     ^ source.hcl.terraform variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl.terraform variable.declaration.hcl
+#       ^^^ source.hcl.terraform
+#          ^ source.hcl.terraform keyword.operator.accessor.hcl
+#           ^^^^ source.hcl.terraform variable.other.member.hcl
+>attr = var.test42
+#^^^^ source.hcl.terraform variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl.terraform variable.declaration.hcl
+#     ^ source.hcl.terraform variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl.terraform variable.declaration.hcl
+#       ^^^ source.hcl.terraform
+#          ^ source.hcl.terraform keyword.operator.accessor.hcl
+#           ^^^^^^ source.hcl.terraform variable.other.member.hcl
+>attr = var.test42test
+#^^^^ source.hcl.terraform variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl.terraform variable.declaration.hcl
+#     ^ source.hcl.terraform variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl.terraform variable.declaration.hcl
+#       ^^^ source.hcl.terraform
+#          ^ source.hcl.terraform keyword.operator.accessor.hcl
+#           ^^^^^^^^^^ source.hcl.terraform variable.other.member.hcl
+>attr = var.test-test
+#^^^^ source.hcl.terraform variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl.terraform variable.declaration.hcl
+#     ^ source.hcl.terraform variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl.terraform variable.declaration.hcl
+#       ^^^ source.hcl.terraform
+#          ^ source.hcl.terraform keyword.operator.accessor.hcl
+#           ^^^^^^^^^ source.hcl.terraform variable.other.member.hcl
+>attr = var.test_test
+#^^^^ source.hcl.terraform variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl.terraform variable.declaration.hcl
+#     ^ source.hcl.terraform variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl.terraform variable.declaration.hcl
+#       ^^^ source.hcl.terraform
+#          ^ source.hcl.terraform keyword.operator.accessor.hcl
+#           ^^^^^^^^^ source.hcl.terraform variable.other.member.hcl
+>attr = traversal
+#^^^^ source.hcl.terraform variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl.terraform variable.declaration.hcl
+#     ^ source.hcl.terraform variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl.terraform variable.declaration.hcl
+#       ^^^^^^^^^^ source.hcl.terraform
+>
+># numeric index
+#^ source.hcl.terraform comment.line.number-sign.hcl punctuation.definition.comment.hcl
+# ^^^^^^^^^^^^^^ source.hcl.terraform comment.line.number-sign.hcl
+>attr = var.test[42]
+#^^^^ source.hcl.terraform variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl.terraform variable.declaration.hcl
+#     ^ source.hcl.terraform variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl.terraform variable.declaration.hcl
+#       ^^^ source.hcl.terraform
+#          ^ source.hcl.terraform keyword.operator.accessor.hcl
+#           ^^^^ source.hcl.terraform variable.other.member.hcl
+#               ^ source.hcl.terraform punctuation.section.brackets.begin.hcl
+#                ^^ source.hcl.terraform constant.numeric.integer.hcl
+#                  ^ source.hcl.terraform punctuation.section.brackets.end.hcl
+>attr = var.test[42][32]
+#^^^^ source.hcl.terraform variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl.terraform variable.declaration.hcl
+#     ^ source.hcl.terraform variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl.terraform variable.declaration.hcl
+#       ^^^ source.hcl.terraform
+#          ^ source.hcl.terraform keyword.operator.accessor.hcl
+#           ^^^^ source.hcl.terraform variable.other.member.hcl
+#               ^ source.hcl.terraform punctuation.section.brackets.begin.hcl
+#                ^^ source.hcl.terraform constant.numeric.integer.hcl
+#                  ^ source.hcl.terraform punctuation.section.brackets.end.hcl
+#                   ^ source.hcl.terraform punctuation.section.brackets.begin.hcl
+#                    ^^ source.hcl.terraform constant.numeric.integer.hcl
+#                      ^ source.hcl.terraform punctuation.section.brackets.end.hcl
+>attr = var.test[42].test
+#^^^^ source.hcl.terraform variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl.terraform variable.declaration.hcl
+#     ^ source.hcl.terraform variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl.terraform variable.declaration.hcl
+#       ^^^ source.hcl.terraform
+#          ^ source.hcl.terraform keyword.operator.accessor.hcl
+#           ^^^^ source.hcl.terraform variable.other.member.hcl
+#               ^ source.hcl.terraform punctuation.section.brackets.begin.hcl
+#                ^^ source.hcl.terraform constant.numeric.integer.hcl
+#                  ^ source.hcl.terraform punctuation.section.brackets.end.hcl
+#                   ^ source.hcl.terraform keyword.operator.accessor.hcl
+#                    ^^^^ source.hcl.terraform variable.other.member.hcl
+>
+># string index
+#^ source.hcl.terraform comment.line.number-sign.hcl punctuation.definition.comment.hcl
+# ^^^^^^^^^^^^^ source.hcl.terraform comment.line.number-sign.hcl
+>attr = var.test["key"]
+#^^^^ source.hcl.terraform variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl.terraform variable.declaration.hcl
+#     ^ source.hcl.terraform variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl.terraform variable.declaration.hcl
+#       ^^^ source.hcl.terraform
+#          ^ source.hcl.terraform keyword.operator.accessor.hcl
+#           ^^^^ source.hcl.terraform variable.other.member.hcl
+#               ^ source.hcl.terraform punctuation.section.brackets.begin.hcl
+#                ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                 ^^^ source.hcl.terraform string.quoted.double.hcl
+#                    ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                     ^ source.hcl.terraform punctuation.section.brackets.end.hcl
+>attr = var.test["key"]["two"]
+#^^^^ source.hcl.terraform variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl.terraform variable.declaration.hcl
+#     ^ source.hcl.terraform variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl.terraform variable.declaration.hcl
+#       ^^^ source.hcl.terraform
+#          ^ source.hcl.terraform keyword.operator.accessor.hcl
+#           ^^^^ source.hcl.terraform variable.other.member.hcl
+#               ^ source.hcl.terraform punctuation.section.brackets.begin.hcl
+#                ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                 ^^^ source.hcl.terraform string.quoted.double.hcl
+#                    ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                     ^ source.hcl.terraform punctuation.section.brackets.end.hcl
+#                      ^ source.hcl.terraform punctuation.section.brackets.begin.hcl
+#                       ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                        ^^^ source.hcl.terraform string.quoted.double.hcl
+#                           ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                            ^ source.hcl.terraform punctuation.section.brackets.end.hcl
+>attr = var.test["key"].test
+#^^^^ source.hcl.terraform variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl.terraform variable.declaration.hcl
+#     ^ source.hcl.terraform variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl.terraform variable.declaration.hcl
+#       ^^^ source.hcl.terraform
+#          ^ source.hcl.terraform keyword.operator.accessor.hcl
+#           ^^^^ source.hcl.terraform variable.other.member.hcl
+#               ^ source.hcl.terraform punctuation.section.brackets.begin.hcl
+#                ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                 ^^^ source.hcl.terraform string.quoted.double.hcl
+#                    ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                     ^ source.hcl.terraform punctuation.section.brackets.end.hcl
+#                      ^ source.hcl.terraform keyword.operator.accessor.hcl
+#                       ^^^^ source.hcl.terraform variable.other.member.hcl
+>
+># legacy numeric index
+#^ source.hcl.terraform comment.line.number-sign.hcl punctuation.definition.comment.hcl
+# ^^^^^^^^^^^^^^^^^^^^^ source.hcl.terraform comment.line.number-sign.hcl
+>attr = var.test.42
+#^^^^ source.hcl.terraform variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl.terraform variable.declaration.hcl
+#     ^ source.hcl.terraform variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl.terraform variable.declaration.hcl
+#       ^^^ source.hcl.terraform
+#          ^ source.hcl.terraform keyword.operator.accessor.hcl
+#           ^^^^ source.hcl.terraform variable.other.member.hcl
+#               ^ source.hcl.terraform keyword.operator.accessor.hcl
+#                ^^ source.hcl.terraform constant.numeric.integer.hcl
+>attr = var.test.42.32
+#^^^^ source.hcl.terraform variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl.terraform variable.declaration.hcl
+#     ^ source.hcl.terraform variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl.terraform variable.declaration.hcl
+#       ^^^ source.hcl.terraform
+#          ^ source.hcl.terraform keyword.operator.accessor.hcl
+#           ^^^^ source.hcl.terraform variable.other.member.hcl
+#               ^ source.hcl.terraform keyword.operator.accessor.hcl
+#                ^^ source.hcl.terraform constant.numeric.integer.hcl
+#                  ^ source.hcl.terraform keyword.operator.accessor.hcl
+#                   ^^ source.hcl.terraform constant.numeric.integer.hcl
+>attr = var.test.42.test
+#^^^^ source.hcl.terraform variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl.terraform variable.declaration.hcl
+#     ^ source.hcl.terraform variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl.terraform variable.declaration.hcl
+#       ^^^ source.hcl.terraform
+#          ^ source.hcl.terraform keyword.operator.accessor.hcl
+#           ^^^^ source.hcl.terraform variable.other.member.hcl
+#               ^ source.hcl.terraform keyword.operator.accessor.hcl
+#                ^^ source.hcl.terraform constant.numeric.integer.hcl
+#                  ^ source.hcl.terraform keyword.operator.accessor.hcl
+#                   ^^^^ source.hcl.terraform variable.other.member.hcl
+>
+># incomplete expression with trailing multiplication operator
+#^ source.hcl.terraform comment.line.number-sign.hcl punctuation.definition.comment.hcl
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl.terraform comment.line.number-sign.hcl
+>attr = var.list*
+#^^^^ source.hcl.terraform variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl.terraform variable.declaration.hcl
+#     ^ source.hcl.terraform variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl.terraform variable.declaration.hcl
+#       ^^^ source.hcl.terraform
+#          ^ source.hcl.terraform keyword.operator.accessor.hcl
+#           ^^^^ source.hcl.terraform variable.other.member.hcl
+#               ^ source.hcl.terraform keyword.operator.arithmetic.hcl
+>
+># ensure this is multiplication and not splat
+#^ source.hcl.terraform comment.line.number-sign.hcl punctuation.definition.comment.hcl
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl.terraform comment.line.number-sign.hcl
+>attr = var.li*st
+#^^^^ source.hcl.terraform variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl.terraform variable.declaration.hcl
+#     ^ source.hcl.terraform variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl.terraform variable.declaration.hcl
+#       ^^^ source.hcl.terraform
+#          ^ source.hcl.terraform keyword.operator.accessor.hcl
+#           ^^ source.hcl.terraform variable.other.member.hcl
+#             ^ source.hcl.terraform keyword.operator.arithmetic.hcl
+#              ^^^ source.hcl.terraform
+>
+># invalid attribute accessor
+#^ source.hcl.terraform comment.line.number-sign.hcl punctuation.definition.comment.hcl
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl.terraform comment.line.number-sign.hcl
+>attr = var.42test
+#^^^^ source.hcl.terraform variable.declaration.hcl variable.other.readwrite.hcl
+#    ^ source.hcl.terraform variable.declaration.hcl
+#     ^ source.hcl.terraform variable.declaration.hcl keyword.operator.assignment.hcl
+#      ^ source.hcl.terraform variable.declaration.hcl
+#       ^^^ source.hcl.terraform
+#          ^ source.hcl.terraform keyword.operator.accessor.hcl
+#           ^^ source.hcl.terraform constant.numeric.integer.hcl
+#             ^^^^^ source.hcl.terraform
+>

--- a/tests/snapshot/terraform/variables_local.tf.snap
+++ b/tests/snapshot/terraform/variables_local.tf.snap
@@ -43,14 +43,16 @@
 #                                    ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl keyword.operator.accessor.hcl
 #                                     ^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl variable.other.member.hcl
 #                                         ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl keyword.operator.accessor.hcl
-#                                          ^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl
+#                                          ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl keyword.operator.splat.hcl
+#                                           ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl keyword.operator.accessor.hcl
 #                                            ^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl variable.other.member.hcl
 #                                              ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl punctuation.separator.hcl
 #                                               ^^^^^^^^^^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl
 #                                                            ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl keyword.operator.accessor.hcl
 #                                                             ^^^^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl variable.other.member.hcl
 #                                                                  ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl keyword.operator.accessor.hcl
-#                                                                   ^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl
+#                                                                   ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl keyword.operator.splat.hcl
+#                                                                    ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl keyword.operator.accessor.hcl
 #                                                                     ^^ source.hcl.terraform meta.block.hcl meta.function-call.hcl variable.other.member.hcl
 #                                                                       ^ source.hcl.terraform meta.block.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
 >}


### PR DESCRIPTION
Fixes https://github.com/hashicorp/syntax/issues/40

After I started looking more closely at the existing tests I realised there is a few more bugs beyond what's described in #40

This fixes handling of the following expressions:

 - legacy numeric indexes (`attribute.0`)
 - legacy splat syntax (`attribute.*`)
 - square brackets around splat syntax (`attribute[*]`)

The PR is best reviewed commit-by-commit, especially because I updated some of the test data to make them more accurate, as per https://github.com/hashicorp/syntax/pull/43#discussion_r889980319

## Before / After

**HCL**
<img src="https://user-images.githubusercontent.com/287584/172328191-1e397f8f-58c2-46a4-aa14-234cd0a29bcc.png" width="49%"><img src="https://user-images.githubusercontent.com/287584/172328244-2630c052-484e-426a-b418-242b29bb05b1.png" width="49%">

**Terraform**

<img src="https://user-images.githubusercontent.com/287584/172329265-a02dccb2-7879-46d3-97f7-15a8b73154de.png" width="49%"><img src="https://user-images.githubusercontent.com/287584/172329277-a415a4a7-a7d6-4aa4-a773-828e12dc9ef5.png" width="49%">

