### PR TITLE
Add Sentinel HCL support

### DIFF
--- a/builder/main.go
+++ b/builder/main.go
@@ -63,6 +63,13 @@ func (c *BuildCommand) Synopsis() string {
 	return "Builds syntax files"
 }
 
+func (c *BuildCommand) newViper(filepath string) (*viper.Viper, error) {
+	v := viper.New()
+	v.SetConfigFile(filepath)
+	err := v.ReadInConfig()
+	return v, err
+}
+
 func (c *BuildCommand) Run(args []string) int {
 	// This currently uses the cwd to find all the files used here
 	// This can be improved in the future to accept User input or use some kind of
@@ -74,40 +81,36 @@ func (c *BuildCommand) Run(args []string) int {
 
 	// The _main.yml file is where all rules in the Patterns and the Repository are defined
 	// Each product file provides specific overrides for rules defined in _main.yml
-	// Here we build a main Viper instance to store the config we will merge in product specific maps to
 	mainFile := filepath.Join(wd, "../src/_main.yml")
-	c.Ui.Info(fmt.Sprintf("Pulling in main template: %s", mainFile))
-	mainViper := viper.New()
-	mainViper.SetConfigFile(mainFile)
-	if err := mainViper.ReadInConfig(); err == nil {
-		c.Ui.Info(fmt.Sprintf("Merging config file: %v", mainViper.ConfigFileUsed()))
-	} else {
-		c.Ui.Error(fmt.Sprintf("Error reading %v: %v", mainViper.ConfigFileUsed(), err))
-		return 1
-	}
 
 	var result *multierror.Error
 	// For each product defined, read the yml and merge into the main Viper instance
 	products := []string{"hcl", "terraform"}
 	for _, product := range products {
 		c.Ui.Info(fmt.Sprintf("Evaluating %s", product))
+
+		// Here we build a main Viper instance to store the config we will merge in product specific maps.
+		// Note that the main viper configuration needs to be re-read for each product and errors here
+		// are terminal
+		mainViper, err := c.newViper(mainFile)
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf("Error reading %v: %v", mainViper.ConfigFileUsed(), err.Error()))
+			result = multierror.Append(result, err)
+			return 1
+		}
+
 		productFile := filepath.Join(wd, fmt.Sprintf("../src/%s.yml", product))
 		c.Ui.Info(fmt.Sprintf("Processing: %s", productFile))
 
 		// Create a product Viper instance that reads each product yml for rules
-		productV := viper.New()
-		productV.SetConfigFile(productFile)
-		if err := productV.ReadInConfig(); err == nil {
-			c.Ui.Info(fmt.Sprintf("Merging config file: %v", productV.ConfigFileUsed()))
-		} else {
+		productV, err := c.newViper(productFile)
+		if err != nil {
 			c.Ui.Error(fmt.Sprintf("Error reading %v: %v", productV.ConfigFileUsed(), err.Error()))
 			result = multierror.Append(result, err)
 			continue
 		}
+		c.Ui.Info(fmt.Sprintf("Merging config file: %v", productV.ConfigFileUsed()))
 
-		// merge the product Viper map into the main Viper instance
-		// This overrides anything already loaded so each product can replace existing
-		// rules and/or provide new ones
 		if err := mainViper.MergeConfigMap(productV.AllSettings()); err != nil {
 			c.Ui.Error(fmt.Sprintf("Unable to merge values from %v: %v", productV.ConfigFileUsed(), err.Error()))
 			result = multierror.Append(result, err)
@@ -117,7 +120,7 @@ func (c *BuildCommand) Run(args []string) int {
 		// Export the merged map to a struct so we can write to file
 		c.Ui.Info(fmt.Sprintf("Building %s", product))
 		var config TextMateGrammar
-		err := mainViper.Unmarshal(&config)
+		err = mainViper.Unmarshal(&config)
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf("Unable to merge values from %s: %s", productV.ConfigFileUsed(), err.Error()))
 			result = multierror.Append(result, err)

--- a/builder/main.go
+++ b/builder/main.go
@@ -85,7 +85,7 @@ func (c *BuildCommand) Run(args []string) int {
 
 	var result *multierror.Error
 	// For each product defined, read the yml and merge into the main Viper instance
-	products := []string{"hcl", "terraform"}
+	products := []string{"hcl", "terraform", "sentinel-hcl"}
 	for _, product := range products {
 		c.Ui.Info(fmt.Sprintf("Evaluating %s", product))
 

--- a/package.json
+++ b/package.json
@@ -17,10 +17,11 @@
     "check": "prettier --check syntaxes/*.json",
     "format": "prettier --write syntaxes/*.json",
     "test": "npm run test:snap",
-    "test:snap": "npm run test:snap:hcl && npm run test:snap:sentinel && npm run test:snap:terraform",
+    "test:snap": "npm run test:snap:hcl && npm run test:snap:sentinel && npm run test:snap:terraform && npm run test:snap:sentinel-hcl",
     "test:snap:update": "npm run test:snap:hcl -- -u && npm run test:snap:sentinel -- -u && npm run test:snap:terraform -- -u",
     "test:snap:hcl": "npx vscode-tmgrammar-snap -s source.hcl -g syntaxes/hcl.tmGrammar.json \"tests/snapshot/hcl/*.hcl\"",
     "test:snap:sentinel": "npx vscode-tmgrammar-snap -s source.sentinel -g syntaxes/sentinel.tmGrammar.json \"tests/snapshot/sentinel/*.sentinel\"",
+    "test:snap:sentinel-hcl": "npx vscode-tmgrammar-snap -s source.hcl.sentinel -g syntaxes/sentinel-hcl.tmGrammar.json \"tests/snapshot/sentinel-hcl/*.hcl\"",
     "test:snap:terraform": "npx vscode-tmgrammar-snap -s source.hcl.terraform -g syntaxes/terraform.tmGrammar.json  -g syntaxes/hcl.tmGrammar.json \"tests/snapshot/terraform/*.tf\""
   },
   "devDependencies": {

--- a/src/sentinel-hcl.yml
+++ b/src/sentinel-hcl.yml
@@ -1,0 +1,33 @@
+scopeName: source.hcl.sentinel
+name: HashiCorp Sentinel Configuration
+uuid: aa94bcc5-d57d-4d1f-a906-b8b8690e8c00
+fileTypes:
+  - hcl
+repository:
+  block:
+    name: meta.block.hcl
+    comment: This will match HCL blocks like `thing1 "one" "two" {` or `thing2 {`
+    # Sentinel attributes can include a forward slash in the name
+    begin: ([\w][\-\w]*)([\s\"\-\w\/]*)(\{)
+    beginCaptures:
+      "1":
+        patterns:
+          - match: \b(?!null|false|true)[[:alpha:]][[:alnum:]_-]*\b
+            comment: Block type
+            name: entity.name.type.hcl
+      "2":
+        patterns:
+          - name: variable.other.enummember.hcl
+            comment: Block label
+            match: '[\"\-\w\/]+'
+      "3":
+        name: punctuation.section.block.begin.hcl
+    end: \}
+    endCaptures:
+      "0":
+        name: punctuation.section.block.end.hcl
+    patterns:
+      - include: "#comments"
+      - include: "#attribute_definition"
+      - include: "#block"
+      - include: "#expressions"

--- a/syntaxes/sentinel-hcl.tmGrammar.json
+++ b/syntaxes/sentinel-hcl.tmGrammar.json
@@ -1,0 +1,782 @@
+{
+  "scopeName": "source.hcl.sentinel",
+  "name": "HashiCorp Sentinel Configuration",
+  "uuid": "aa94bcc5-d57d-4d1f-a906-b8b8690e8c00",
+  "fileTypes": [
+    "hcl"
+  ],
+  "patterns": [
+    {
+      "include": "#comments"
+    },
+    {
+      "include": "#attribute_definition"
+    },
+    {
+      "include": "#block"
+    },
+    {
+      "include": "#expressions"
+    }
+  ],
+  "repository": {
+    "attribute_access": {
+      "begin": "\\.(?!\\*)",
+      "end": "[[:alpha:]][\\w-]*|\\d*",
+      "comment": "Matches traversal attribute access such as .attr",
+      "beginCaptures": {
+        "0": {
+          "name": "keyword.operator.accessor.hcl"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "patterns": [
+            {
+              "match": "(?!null|false|true)[[:alpha:]][\\w-]*",
+              "comment": "Attribute name",
+              "name": "variable.other.member.hcl"
+            },
+            {
+              "match": "\\d+",
+              "comment": "Optional attribute index",
+              "name": "constant.numeric.integer.hcl"
+            }
+          ]
+        }
+      }
+    },
+    "attribute_definition": {
+      "name": "variable.declaration.hcl",
+      "match": "(\\()?((?!null|false|true)[[:alpha:]][[:alnum:]_-]*)(\\))?\\s*(\\=(?!\\=|\\>))\\s*",
+      "comment": "Identifier \"=\" with optional parens",
+      "captures": {
+        "1": {
+          "name": "punctuation.section.parens.begin.hcl"
+        },
+        "2": {
+          "name": "variable.other.readwrite.hcl"
+        },
+        "3": {
+          "name": "punctuation.section.parens.end.hcl"
+        },
+        "4": {
+          "name": "keyword.operator.assignment.hcl"
+        }
+      }
+    },
+    "attribute_splat": {
+      "begin": "\\.",
+      "end": "\\*",
+      "comment": "Legacy attribute-only splat",
+      "beginCaptures": {
+        "0": {
+          "name": "keyword.operator.accessor.hcl"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "keyword.operator.splat.hcl"
+        }
+      }
+    },
+    "block": {
+      "name": "meta.block.hcl",
+      "begin": "([\\w][\\-\\w]*)([\\s\\\"\\-\\w\\/]*)(\\{)",
+      "end": "\\}",
+      "comment": "This will match HCL blocks like `thing1 \"one\" \"two\" {` or `thing2 {`",
+      "beginCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "match": "\\b(?!null|false|true)[[:alpha:]][[:alnum:]_-]*\\b",
+              "comment": "Block type",
+              "name": "entity.name.type.hcl"
+            }
+          ]
+        },
+        "2": {
+          "patterns": [
+            {
+              "match": "[\\\"\\-\\w\\/]+",
+              "comment": "Block label",
+              "name": "variable.other.enummember.hcl"
+            }
+          ]
+        },
+        "3": {
+          "name": "punctuation.section.block.begin.hcl"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.block.end.hcl"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#attribute_definition"
+        },
+        {
+          "include": "#block"
+        },
+        {
+          "include": "#expressions"
+        }
+      ]
+    },
+    "block_inline_comments": {
+      "name": "comment.block.hcl",
+      "begin": "/\\*",
+      "end": "\\*/",
+      "comment": "Inline comments start with the /* sequence and end with the */ sequence, and may have any characters within except the ending sequence. An inline comment is considered equivalent to a whitespace sequence",
+      "captures": {
+        "0": {
+          "name": "punctuation.definition.comment.hcl"
+        }
+      }
+    },
+    "brackets": {
+      "begin": "\\[",
+      "end": "\\]",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.brackets.begin.hcl"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.brackets.end.hcl"
+        }
+      },
+      "patterns": [
+        {
+          "name": "keyword.operator.splat.hcl",
+          "match": "\\*",
+          "comment": "Splat operator"
+        },
+        {
+          "include": "#comma"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#inline_for_expression"
+        },
+        {
+          "include": "#inline_if_expression"
+        },
+        {
+          "include": "#expressions"
+        },
+        {
+          "include": "#local_identifiers"
+        }
+      ]
+    },
+    "char_escapes": {
+      "name": "constant.character.escape.hcl",
+      "match": "\\\\[nrt\"\\\\]|\\\\u(\\h{8}|\\h{4})",
+      "comment": "Character Escapes"
+    },
+    "comma": {
+      "name": "punctuation.separator.hcl",
+      "match": "\\,",
+      "comment": "Commas - used in certain expressions"
+    },
+    "comments": {
+      "patterns": [
+        {
+          "include": "#hash_line_comments"
+        },
+        {
+          "include": "#double_slash_line_comments"
+        },
+        {
+          "include": "#block_inline_comments"
+        }
+      ]
+    },
+    "double_slash_line_comments": {
+      "name": "comment.line.double-slash.hcl",
+      "begin": "//",
+      "end": "$\\n?",
+      "comment": "Line comments start with // sequence and end with the next newline sequence. A line comment is considered equivalent to a newline sequence",
+      "captures": {
+        "0": {
+          "name": "punctuation.definition.comment.hcl"
+        }
+      }
+    },
+    "expressions": {
+      "patterns": [
+        {
+          "include": "#literal_values"
+        },
+        {
+          "include": "#operators"
+        },
+        {
+          "include": "#tuple_for_expression"
+        },
+        {
+          "include": "#object_for_expression"
+        },
+        {
+          "include": "#brackets"
+        },
+        {
+          "include": "#objects"
+        },
+        {
+          "include": "#attribute_access"
+        },
+        {
+          "include": "#attribute_splat"
+        },
+        {
+          "include": "#functions"
+        },
+        {
+          "include": "#parens"
+        }
+      ]
+    },
+    "for_expression_body": {
+      "patterns": [
+        {
+          "name": "keyword.operator.word.hcl",
+          "match": "\\bin\\b",
+          "comment": "in keyword"
+        },
+        {
+          "name": "keyword.control.conditional.hcl",
+          "match": "\\bif\\b",
+          "comment": "if keyword"
+        },
+        {
+          "name": "keyword.operator.hcl",
+          "match": "\\:"
+        },
+        {
+          "include": "#expressions"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#comma"
+        },
+        {
+          "include": "#local_identifiers"
+        }
+      ]
+    },
+    "functions": {
+      "name": "meta.function-call.hcl",
+      "begin": "(\\w+)(\\()",
+      "end": "\\)",
+      "comment": "Built-in function calls",
+      "beginCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "match": "\\b(?!null|false|true)[[:alpha:]][[:alnum:]_-]*\\b",
+              "name": "support.function.builtin.hcl"
+            }
+          ]
+        },
+        "2": {
+          "name": "punctuation.section.parens.begin.hcl"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.parens.end.hcl"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#expressions"
+        },
+        {
+          "include": "#comma"
+        }
+      ]
+    },
+    "hash_line_comments": {
+      "name": "comment.line.number-sign.hcl",
+      "begin": "#",
+      "end": "$\\n?",
+      "comment": "Line comments start with # sequence and end with the next newline sequence. A line comment is considered equivalent to a newline sequence",
+      "captures": {
+        "0": {
+          "name": "punctuation.definition.comment.hcl"
+        }
+      }
+    },
+    "hcl_type_keywords": {
+      "name": "storage.type.hcl",
+      "match": "\\b(any|string|number|bool|list|set|map|tuple|object)\\b",
+      "comment": "Type keywords known to HCL."
+    },
+    "heredoc": {
+      "name": "string.unquoted.heredoc.hcl",
+      "begin": "(\\<\\<\\-?)\\s*(\\w+)\\s*$",
+      "end": "^\\s*\\2\\s*$",
+      "comment": "String Heredoc",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.operator.heredoc.hcl"
+        },
+        "2": {
+          "name": "keyword.control.heredoc.hcl"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "keyword.control.heredoc.hcl"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#string_interpolation"
+        }
+      ]
+    },
+    "inline_for_expression": {
+      "begin": "(for)\\b",
+      "end": "\\n",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.hcl"
+        }
+      },
+      "patterns": [
+        {
+          "name": "storage.type.function.hcl",
+          "match": "\\=\\>"
+        },
+        {
+          "include": "#for_expression_body"
+        }
+      ]
+    },
+    "inline_if_expression": {
+      "begin": "(if)\\b",
+      "end": "\\n",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.conditional.hcl"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#expressions"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#comma"
+        },
+        {
+          "include": "#local_identifiers"
+        }
+      ]
+    },
+    "language_constants": {
+      "name": "constant.language.hcl",
+      "match": "\\b(true|false|null)\\b",
+      "comment": "Language Constants"
+    },
+    "literal_values": {
+      "patterns": [
+        {
+          "include": "#numeric_literals"
+        },
+        {
+          "include": "#language_constants"
+        },
+        {
+          "include": "#string_literals"
+        },
+        {
+          "include": "#heredoc"
+        },
+        {
+          "include": "#hcl_type_keywords"
+        }
+      ]
+    },
+    "local_identifiers": {
+      "name": "variable.other.readwrite.hcl",
+      "match": "\\b(?!null|false|true)[[:alpha:]][[:alnum:]_-]*\\b",
+      "comment": "Local Identifiers"
+    },
+    "numeric_literals": {
+      "patterns": [
+        {
+          "name": "constant.numeric.float.hcl",
+          "match": "\\b\\d+([Ee][+-]?)\\d+\\b",
+          "comment": "Integer, no fraction, optional exponent",
+          "captures": {
+            "1": {
+              "name": "punctuation.separator.exponent.hcl"
+            }
+          }
+        },
+        {
+          "name": "constant.numeric.float.hcl",
+          "match": "\\b\\d+(\\.)\\d+(?:([Ee][+-]?)\\d+)?\\b",
+          "comment": "Integer, fraction, optional exponent",
+          "captures": {
+            "1": {
+              "name": "punctuation.separator.decimal.hcl"
+            },
+            "2": {
+              "name": "punctuation.separator.exponent.hcl"
+            }
+          }
+        },
+        {
+          "name": "constant.numeric.integer.hcl",
+          "match": "\\b\\d+\\b",
+          "comment": "Integers"
+        }
+      ]
+    },
+    "object_for_expression": {
+      "begin": "(\\{)\\s?(for)\\b",
+      "end": "\\}",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.section.braces.begin.hcl"
+        },
+        "2": {
+          "name": "keyword.control.hcl"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.braces.end.hcl"
+        }
+      },
+      "patterns": [
+        {
+          "name": "storage.type.function.hcl",
+          "match": "\\=\\>"
+        },
+        {
+          "include": "#for_expression_body"
+        }
+      ]
+    },
+    "object_key_values": {
+      "patterns": [
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#literal_values"
+        },
+        {
+          "include": "#operators"
+        },
+        {
+          "include": "#tuple_for_expression"
+        },
+        {
+          "include": "#object_for_expression"
+        },
+        {
+          "include": "#heredoc"
+        },
+        {
+          "include": "#functions"
+        }
+      ]
+    },
+    "objects": {
+      "name": "meta.braces.hcl",
+      "begin": "\\{",
+      "end": "\\}",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.braces.begin.hcl"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.braces.end.hcl"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#objects"
+        },
+        {
+          "include": "#inline_for_expression"
+        },
+        {
+          "include": "#inline_if_expression"
+        },
+        {
+          "match": "\\b((?!null|false|true)[[:alpha:]][[:alnum:]_-]*)\\s*(\\=\\>?)\\s*",
+          "comment": "Literal, named object key",
+          "captures": {
+            "1": {
+              "name": "meta.mapping.key.hcl variable.other.readwrite.hcl"
+            },
+            "2": {
+              "name": "keyword.operator.assignment.hcl",
+              "patterns": [
+                {
+                  "match": "\\=\\>",
+                  "name": "storage.type.function.hcl"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "match": "\\b((\").*(\"))\\s*(\\=)\\s*",
+          "comment": "String object key",
+          "captures": {
+            "1": {
+              "name": "meta.mapping.key.hcl string.quoted.double.hcl"
+            },
+            "2": {
+              "name": "punctuation.definition.string.begin.hcl"
+            },
+            "3": {
+              "name": "punctuation.definition.string.end.hcl"
+            },
+            "4": {
+              "name": "keyword.operator.hcl"
+            }
+          }
+        },
+        {
+          "name": "meta.mapping.key.hcl",
+          "begin": "^\\s*\\(",
+          "end": "(\\))\\s*(=|:)\\s*",
+          "comment": "Computed object key (any expression between parens)",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.section.parens.begin.hcl"
+            }
+          },
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.section.parens.end.hcl"
+            },
+            "2": {
+              "name": "keyword.operator.hcl"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#attribute_access"
+            },
+            {
+              "include": "#attribute_splat"
+            }
+          ]
+        },
+        {
+          "include": "#object_key_values"
+        }
+      ]
+    },
+    "operators": {
+      "patterns": [
+        {
+          "name": "keyword.operator.hcl",
+          "match": "\\>\\="
+        },
+        {
+          "name": "keyword.operator.hcl",
+          "match": "\\<\\="
+        },
+        {
+          "name": "keyword.operator.hcl",
+          "match": "\\=\\="
+        },
+        {
+          "name": "keyword.operator.hcl",
+          "match": "\\!\\="
+        },
+        {
+          "name": "keyword.operator.arithmetic.hcl",
+          "match": "\\+"
+        },
+        {
+          "name": "keyword.operator.arithmetic.hcl",
+          "match": "\\-"
+        },
+        {
+          "name": "keyword.operator.arithmetic.hcl",
+          "match": "\\*"
+        },
+        {
+          "name": "keyword.operator.arithmetic.hcl",
+          "match": "\\/"
+        },
+        {
+          "name": "keyword.operator.arithmetic.hcl",
+          "match": "\\%"
+        },
+        {
+          "name": "keyword.operator.logical.hcl",
+          "match": "\\&\\&"
+        },
+        {
+          "name": "keyword.operator.logical.hcl",
+          "match": "\\|\\|"
+        },
+        {
+          "name": "keyword.operator.logical.hcl",
+          "match": "\\!"
+        },
+        {
+          "name": "keyword.operator.hcl",
+          "match": "\\>"
+        },
+        {
+          "name": "keyword.operator.hcl",
+          "match": "\\<"
+        },
+        {
+          "name": "keyword.operator.hcl",
+          "match": "\\?"
+        },
+        {
+          "name": "keyword.operator.hcl",
+          "match": "\\.\\.\\."
+        },
+        {
+          "match": "\\:"
+        }
+      ]
+    },
+    "parens": {
+      "begin": "\\(",
+      "end": "\\)",
+      "comment": "Parens - matched *after* function syntax",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.parens.begin.hcl"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.parens.end.hcl"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#expressions"
+        }
+      ]
+    },
+    "string_interpolation": {
+      "name": "meta.interpolation.hcl",
+      "begin": "(?<![%$])([%$]{)",
+      "end": "\\}",
+      "comment": "String interpolation",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.interpolation.begin.hcl"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "keyword.other.interpolation.end.hcl"
+        }
+      },
+      "patterns": [
+        {
+          "name": "keyword.operator.template.left.trim.hcl",
+          "match": "\\~\\s",
+          "comment": "Trim left whitespace"
+        },
+        {
+          "name": "keyword.operator.template.right.trim.hcl",
+          "match": "\\s\\~",
+          "comment": "Trim right whitespace"
+        },
+        {
+          "name": "keyword.control.hcl",
+          "match": "\\b(if|else|endif|for|in|endfor)\\b",
+          "comment": "if/else/endif and for/in/endfor directives"
+        },
+        {
+          "include": "#expressions"
+        },
+        {
+          "include": "#local_identifiers"
+        }
+      ]
+    },
+    "string_literals": {
+      "name": "string.quoted.double.hcl",
+      "begin": "\"",
+      "end": "\"",
+      "comment": "Strings",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.hcl"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.hcl"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#string_interpolation"
+        },
+        {
+          "include": "#char_escapes"
+        }
+      ]
+    },
+    "tuple_for_expression": {
+      "begin": "(\\[)\\s?(for)\\b",
+      "end": "\\]",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.section.brackets.begin.hcl"
+        },
+        "2": {
+          "name": "keyword.control.hcl"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.brackets.end.hcl"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#for_expression_body"
+        }
+      ]
+    }
+  }
+}

--- a/tests/snapshot/sentinel-hcl/basic-config.hcl
+++ b/tests/snapshot/sentinel-hcl/basic-config.hcl
@@ -1,0 +1,24 @@
+module "something" {
+  source = "./modules/something.sentinel"
+}
+
+policy "policy1" {
+  source = "./policies/policy1/policy1.sentinel"
+  enforcement_level = "hard-mandatory"
+}
+
+policy "policy2" {
+  source = "./policies/policy2/policy2.sentinel"
+}
+
+global "time" {
+  value = {
+    now = {
+      day = 31
+    }
+  }
+}
+
+param "foo" {
+  value = "bar"
+}

--- a/tests/snapshot/sentinel-hcl/basic-config.hcl.snap
+++ b/tests/snapshot/sentinel-hcl/basic-config.hcl.snap
@@ -1,0 +1,117 @@
+>module "something" {
+#^^^^^^ source.hcl.sentinel meta.block.hcl entity.name.type.hcl
+#      ^ source.hcl.sentinel meta.block.hcl
+#       ^^^^^^^^^^^ source.hcl.sentinel meta.block.hcl variable.other.enummember.hcl
+#                  ^ source.hcl.sentinel meta.block.hcl
+#                   ^ source.hcl.sentinel meta.block.hcl punctuation.section.block.begin.hcl
+>  source = "./modules/something.sentinel"
+#^^ source.hcl.sentinel meta.block.hcl
+#  ^^^^^^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#        ^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl
+#         ^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#          ^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl
+#           ^ source.hcl.sentinel meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl.sentinel meta.block.hcl string.quoted.double.hcl
+#                                        ^ source.hcl.sentinel meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+>}
+#^ source.hcl.sentinel meta.block.hcl punctuation.section.block.end.hcl
+>
+>policy "policy1" {
+#^^^^^^ source.hcl.sentinel meta.block.hcl entity.name.type.hcl
+#      ^ source.hcl.sentinel meta.block.hcl
+#       ^^^^^^^^^ source.hcl.sentinel meta.block.hcl variable.other.enummember.hcl
+#                ^ source.hcl.sentinel meta.block.hcl
+#                 ^ source.hcl.sentinel meta.block.hcl punctuation.section.block.begin.hcl
+>  source = "./policies/policy1/policy1.sentinel"
+#^^ source.hcl.sentinel meta.block.hcl
+#  ^^^^^^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#        ^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl
+#         ^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#          ^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl
+#           ^ source.hcl.sentinel meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl.sentinel meta.block.hcl string.quoted.double.hcl
+#                                               ^ source.hcl.sentinel meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+>  enforcement_level = "hard-mandatory"
+#^^ source.hcl.sentinel meta.block.hcl
+#  ^^^^^^^^^^^^^^^^^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#                   ^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl
+#                    ^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#                     ^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl
+#                      ^ source.hcl.sentinel meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                       ^^^^^^^^^^^^^^ source.hcl.sentinel meta.block.hcl string.quoted.double.hcl
+#                                     ^ source.hcl.sentinel meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+>}
+#^ source.hcl.sentinel meta.block.hcl punctuation.section.block.end.hcl
+>
+>policy "policy2" {
+#^^^^^^ source.hcl.sentinel meta.block.hcl entity.name.type.hcl
+#      ^ source.hcl.sentinel meta.block.hcl
+#       ^^^^^^^^^ source.hcl.sentinel meta.block.hcl variable.other.enummember.hcl
+#                ^ source.hcl.sentinel meta.block.hcl
+#                 ^ source.hcl.sentinel meta.block.hcl punctuation.section.block.begin.hcl
+>  source = "./policies/policy2/policy2.sentinel"
+#^^ source.hcl.sentinel meta.block.hcl
+#  ^^^^^^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#        ^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl
+#         ^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#          ^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl
+#           ^ source.hcl.sentinel meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl.sentinel meta.block.hcl string.quoted.double.hcl
+#                                               ^ source.hcl.sentinel meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+>}
+#^ source.hcl.sentinel meta.block.hcl punctuation.section.block.end.hcl
+>
+>global "time" {
+#^^^^^^ source.hcl.sentinel meta.block.hcl entity.name.type.hcl
+#      ^ source.hcl.sentinel meta.block.hcl
+#       ^^^^^^ source.hcl.sentinel meta.block.hcl variable.other.enummember.hcl
+#             ^ source.hcl.sentinel meta.block.hcl
+#              ^ source.hcl.sentinel meta.block.hcl punctuation.section.block.begin.hcl
+>  value = {
+#^^ source.hcl.sentinel meta.block.hcl
+#  ^^^^^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#       ^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl
+#        ^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#         ^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl
+#          ^ source.hcl.sentinel meta.block.hcl meta.braces.hcl punctuation.section.braces.begin.hcl
+>    now = {
+#^^^^ source.hcl.sentinel meta.block.hcl meta.braces.hcl
+#    ^^^ source.hcl.sentinel meta.block.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
+#       ^ source.hcl.sentinel meta.block.hcl meta.braces.hcl
+#        ^ source.hcl.sentinel meta.block.hcl meta.braces.hcl keyword.operator.assignment.hcl
+#         ^ source.hcl.sentinel meta.block.hcl meta.braces.hcl
+#          ^ source.hcl.sentinel meta.block.hcl meta.braces.hcl meta.braces.hcl punctuation.section.braces.begin.hcl
+>      day = 31
+#^^^^^^ source.hcl.sentinel meta.block.hcl meta.braces.hcl meta.braces.hcl
+#      ^^^ source.hcl.sentinel meta.block.hcl meta.braces.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
+#         ^ source.hcl.sentinel meta.block.hcl meta.braces.hcl meta.braces.hcl
+#          ^ source.hcl.sentinel meta.block.hcl meta.braces.hcl meta.braces.hcl keyword.operator.assignment.hcl
+#           ^ source.hcl.sentinel meta.block.hcl meta.braces.hcl meta.braces.hcl
+#            ^^ source.hcl.sentinel meta.block.hcl meta.braces.hcl meta.braces.hcl constant.numeric.integer.hcl
+>    }
+#^^^^ source.hcl.sentinel meta.block.hcl meta.braces.hcl meta.braces.hcl
+#    ^ source.hcl.sentinel meta.block.hcl meta.braces.hcl meta.braces.hcl punctuation.section.braces.end.hcl
+>  }
+#^^ source.hcl.sentinel meta.block.hcl meta.braces.hcl
+#  ^ source.hcl.sentinel meta.block.hcl meta.braces.hcl punctuation.section.braces.end.hcl
+>}
+#^ source.hcl.sentinel meta.block.hcl punctuation.section.block.end.hcl
+>
+>param "foo" {
+#^^^^^ source.hcl.sentinel meta.block.hcl entity.name.type.hcl
+#     ^ source.hcl.sentinel meta.block.hcl
+#      ^^^^^ source.hcl.sentinel meta.block.hcl variable.other.enummember.hcl
+#           ^ source.hcl.sentinel meta.block.hcl
+#            ^ source.hcl.sentinel meta.block.hcl punctuation.section.block.begin.hcl
+>  value = "bar"
+#^^ source.hcl.sentinel meta.block.hcl
+#  ^^^^^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#       ^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl
+#        ^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#         ^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl
+#          ^ source.hcl.sentinel meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#           ^^^ source.hcl.sentinel meta.block.hcl string.quoted.double.hcl
+#              ^ source.hcl.sentinel meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+>}
+#^ source.hcl.sentinel meta.block.hcl punctuation.section.block.end.hcl
+>

--- a/tests/snapshot/sentinel-hcl/basic-test.hcl
+++ b/tests/snapshot/sentinel-hcl/basic-test.hcl
@@ -1,0 +1,20 @@
+mock "tfplan/v2" {
+  module {
+    source = "../../testdata/mock-tfplan-success.sentinel"
+  }
+}
+
+mock "time" {
+  data = {
+    now = {
+      hour = 9
+      minute = 42
+    }
+  }
+}
+
+test {
+  rules = {
+    main = true
+  }
+}

--- a/tests/snapshot/sentinel-hcl/basic-test.hcl.snap
+++ b/tests/snapshot/sentinel-hcl/basic-test.hcl.snap
@@ -1,0 +1,93 @@
+>mock "tfplan/v2" {
+#^^^^ source.hcl.sentinel meta.block.hcl entity.name.type.hcl
+#    ^ source.hcl.sentinel meta.block.hcl
+#     ^^^^^^^^^^^ source.hcl.sentinel meta.block.hcl variable.other.enummember.hcl
+#                ^ source.hcl.sentinel meta.block.hcl
+#                 ^ source.hcl.sentinel meta.block.hcl punctuation.section.block.begin.hcl
+>  module {
+#^^ source.hcl.sentinel meta.block.hcl
+#  ^^^^^^ source.hcl.sentinel meta.block.hcl meta.block.hcl entity.name.type.hcl
+#        ^ source.hcl.sentinel meta.block.hcl meta.block.hcl
+#         ^ source.hcl.sentinel meta.block.hcl meta.block.hcl punctuation.section.block.begin.hcl
+>    source = "../../testdata/mock-tfplan-success.sentinel"
+#^^^^ source.hcl.sentinel meta.block.hcl meta.block.hcl
+#    ^^^^^^ source.hcl.sentinel meta.block.hcl meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#          ^ source.hcl.sentinel meta.block.hcl meta.block.hcl variable.declaration.hcl
+#           ^ source.hcl.sentinel meta.block.hcl meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#            ^ source.hcl.sentinel meta.block.hcl meta.block.hcl variable.declaration.hcl
+#             ^ source.hcl.sentinel meta.block.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl.sentinel meta.block.hcl meta.block.hcl string.quoted.double.hcl
+#                                                         ^ source.hcl.sentinel meta.block.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+>  }
+#^^ source.hcl.sentinel meta.block.hcl meta.block.hcl
+#  ^ source.hcl.sentinel meta.block.hcl meta.block.hcl punctuation.section.block.end.hcl
+>}
+#^ source.hcl.sentinel meta.block.hcl punctuation.section.block.end.hcl
+>
+>mock "time" {
+#^^^^ source.hcl.sentinel meta.block.hcl entity.name.type.hcl
+#    ^ source.hcl.sentinel meta.block.hcl
+#     ^^^^^^ source.hcl.sentinel meta.block.hcl variable.other.enummember.hcl
+#           ^ source.hcl.sentinel meta.block.hcl
+#            ^ source.hcl.sentinel meta.block.hcl punctuation.section.block.begin.hcl
+>  data = {
+#^^ source.hcl.sentinel meta.block.hcl
+#  ^^^^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#      ^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl
+#       ^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#        ^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl
+#         ^ source.hcl.sentinel meta.block.hcl meta.braces.hcl punctuation.section.braces.begin.hcl
+>    now = {
+#^^^^ source.hcl.sentinel meta.block.hcl meta.braces.hcl
+#    ^^^ source.hcl.sentinel meta.block.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
+#       ^ source.hcl.sentinel meta.block.hcl meta.braces.hcl
+#        ^ source.hcl.sentinel meta.block.hcl meta.braces.hcl keyword.operator.assignment.hcl
+#         ^ source.hcl.sentinel meta.block.hcl meta.braces.hcl
+#          ^ source.hcl.sentinel meta.block.hcl meta.braces.hcl meta.braces.hcl punctuation.section.braces.begin.hcl
+>      hour = 9
+#^^^^^^ source.hcl.sentinel meta.block.hcl meta.braces.hcl meta.braces.hcl
+#      ^^^^ source.hcl.sentinel meta.block.hcl meta.braces.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
+#          ^ source.hcl.sentinel meta.block.hcl meta.braces.hcl meta.braces.hcl
+#           ^ source.hcl.sentinel meta.block.hcl meta.braces.hcl meta.braces.hcl keyword.operator.assignment.hcl
+#            ^ source.hcl.sentinel meta.block.hcl meta.braces.hcl meta.braces.hcl
+#             ^ source.hcl.sentinel meta.block.hcl meta.braces.hcl meta.braces.hcl constant.numeric.integer.hcl
+>      minute = 42
+#^^^^^^ source.hcl.sentinel meta.block.hcl meta.braces.hcl meta.braces.hcl
+#      ^^^^^^ source.hcl.sentinel meta.block.hcl meta.braces.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
+#            ^ source.hcl.sentinel meta.block.hcl meta.braces.hcl meta.braces.hcl
+#             ^ source.hcl.sentinel meta.block.hcl meta.braces.hcl meta.braces.hcl keyword.operator.assignment.hcl
+#              ^ source.hcl.sentinel meta.block.hcl meta.braces.hcl meta.braces.hcl
+#               ^^ source.hcl.sentinel meta.block.hcl meta.braces.hcl meta.braces.hcl constant.numeric.integer.hcl
+>    }
+#^^^^ source.hcl.sentinel meta.block.hcl meta.braces.hcl meta.braces.hcl
+#    ^ source.hcl.sentinel meta.block.hcl meta.braces.hcl meta.braces.hcl punctuation.section.braces.end.hcl
+>  }
+#^^ source.hcl.sentinel meta.block.hcl meta.braces.hcl
+#  ^ source.hcl.sentinel meta.block.hcl meta.braces.hcl punctuation.section.braces.end.hcl
+>}
+#^ source.hcl.sentinel meta.block.hcl punctuation.section.block.end.hcl
+>
+>test {
+#^^^^ source.hcl.sentinel meta.block.hcl entity.name.type.hcl
+#    ^ source.hcl.sentinel meta.block.hcl
+#     ^ source.hcl.sentinel meta.block.hcl punctuation.section.block.begin.hcl
+>  rules = {
+#^^ source.hcl.sentinel meta.block.hcl
+#  ^^^^^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#       ^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl
+#        ^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#         ^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl
+#          ^ source.hcl.sentinel meta.block.hcl meta.braces.hcl punctuation.section.braces.begin.hcl
+>    main = true
+#^^^^ source.hcl.sentinel meta.block.hcl meta.braces.hcl
+#    ^^^^ source.hcl.sentinel meta.block.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
+#        ^ source.hcl.sentinel meta.block.hcl meta.braces.hcl
+#         ^ source.hcl.sentinel meta.block.hcl meta.braces.hcl keyword.operator.assignment.hcl
+#          ^ source.hcl.sentinel meta.block.hcl meta.braces.hcl
+#           ^^^^ source.hcl.sentinel meta.block.hcl meta.braces.hcl constant.language.hcl
+>  }
+#^^ source.hcl.sentinel meta.block.hcl meta.braces.hcl
+#  ^ source.hcl.sentinel meta.block.hcl meta.braces.hcl punctuation.section.braces.end.hcl
+>}
+#^ source.hcl.sentinel meta.block.hcl punctuation.section.block.end.hcl
+>

--- a/tests/snapshot/sentinel-hcl/test-2.hcl
+++ b/tests/snapshot/sentinel-hcl/test-2.hcl
@@ -1,0 +1,15 @@
+param "day" {
+  value = "monday"
+}
+
+param "hour" {
+  value = 7
+}
+
+test {
+  rules = {
+    main          = false
+    is_open_hours = false
+    is_weekday    = true
+  }
+}

--- a/tests/snapshot/sentinel-hcl/test-2.hcl.snap
+++ b/tests/snapshot/sentinel-hcl/test-2.hcl.snap
@@ -1,0 +1,72 @@
+>param "day" {
+#^^^^^ source.hcl.sentinel meta.block.hcl entity.name.type.hcl
+#     ^ source.hcl.sentinel meta.block.hcl
+#      ^^^^^ source.hcl.sentinel meta.block.hcl variable.other.enummember.hcl
+#           ^ source.hcl.sentinel meta.block.hcl
+#            ^ source.hcl.sentinel meta.block.hcl punctuation.section.block.begin.hcl
+>  value = "monday"
+#^^ source.hcl.sentinel meta.block.hcl
+#  ^^^^^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#       ^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl
+#        ^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#         ^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl
+#          ^ source.hcl.sentinel meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#           ^^^^^^ source.hcl.sentinel meta.block.hcl string.quoted.double.hcl
+#                 ^ source.hcl.sentinel meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+>}
+#^ source.hcl.sentinel meta.block.hcl punctuation.section.block.end.hcl
+>
+>param "hour" {
+#^^^^^ source.hcl.sentinel meta.block.hcl entity.name.type.hcl
+#     ^ source.hcl.sentinel meta.block.hcl
+#      ^^^^^^ source.hcl.sentinel meta.block.hcl variable.other.enummember.hcl
+#            ^ source.hcl.sentinel meta.block.hcl
+#             ^ source.hcl.sentinel meta.block.hcl punctuation.section.block.begin.hcl
+>  value = 7
+#^^ source.hcl.sentinel meta.block.hcl
+#  ^^^^^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#       ^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl
+#        ^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#         ^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl
+#          ^ source.hcl.sentinel meta.block.hcl constant.numeric.integer.hcl
+>}
+#^ source.hcl.sentinel meta.block.hcl punctuation.section.block.end.hcl
+>
+>test {
+#^^^^ source.hcl.sentinel meta.block.hcl entity.name.type.hcl
+#    ^ source.hcl.sentinel meta.block.hcl
+#     ^ source.hcl.sentinel meta.block.hcl punctuation.section.block.begin.hcl
+>  rules = {
+#^^ source.hcl.sentinel meta.block.hcl
+#  ^^^^^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#       ^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl
+#        ^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#         ^ source.hcl.sentinel meta.block.hcl variable.declaration.hcl
+#          ^ source.hcl.sentinel meta.block.hcl meta.braces.hcl punctuation.section.braces.begin.hcl
+>    main          = false
+#^^^^ source.hcl.sentinel meta.block.hcl meta.braces.hcl
+#    ^^^^ source.hcl.sentinel meta.block.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
+#        ^^^^^^^^^^ source.hcl.sentinel meta.block.hcl meta.braces.hcl
+#                  ^ source.hcl.sentinel meta.block.hcl meta.braces.hcl keyword.operator.assignment.hcl
+#                   ^ source.hcl.sentinel meta.block.hcl meta.braces.hcl
+#                    ^^^^^ source.hcl.sentinel meta.block.hcl meta.braces.hcl constant.language.hcl
+>    is_open_hours = false
+#^^^^ source.hcl.sentinel meta.block.hcl meta.braces.hcl
+#    ^^^^^^^^^^^^^ source.hcl.sentinel meta.block.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
+#                 ^ source.hcl.sentinel meta.block.hcl meta.braces.hcl
+#                  ^ source.hcl.sentinel meta.block.hcl meta.braces.hcl keyword.operator.assignment.hcl
+#                   ^ source.hcl.sentinel meta.block.hcl meta.braces.hcl
+#                    ^^^^^ source.hcl.sentinel meta.block.hcl meta.braces.hcl constant.language.hcl
+>    is_weekday    = true
+#^^^^ source.hcl.sentinel meta.block.hcl meta.braces.hcl
+#    ^^^^^^^^^^ source.hcl.sentinel meta.block.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
+#              ^^^^ source.hcl.sentinel meta.block.hcl meta.braces.hcl
+#                  ^ source.hcl.sentinel meta.block.hcl meta.braces.hcl keyword.operator.assignment.hcl
+#                   ^ source.hcl.sentinel meta.block.hcl meta.braces.hcl
+#                    ^^^^ source.hcl.sentinel meta.block.hcl meta.braces.hcl constant.language.hcl
+>  }
+#^^ source.hcl.sentinel meta.block.hcl meta.braces.hcl
+#  ^ source.hcl.sentinel meta.block.hcl meta.braces.hcl punctuation.section.braces.end.hcl
+>}
+#^ source.hcl.sentinel meta.block.hcl punctuation.section.block.end.hcl
+>


### PR DESCRIPTION
This commit adds a Sentinel HCL specific grammar file. This should be used
with the root Sentinel configuration file (Sentinel.hcl) as per [1]. It
should also be used with Sentinel Test configuration files (*.hcl) as per [2]

[1] https://docs.hashicorp.com/sentinel/configuration#configuration-file-reference
[2] https://docs.hashicorp.com/sentinel/writing/testing#test-case-format