### PR TITLE
Improve attribute name matching

### DIFF
--- a/src/_main.yml
+++ b/src/_main.yml
@@ -58,7 +58,7 @@ repository:
         name: punctuation.definition.comment.hcl
     end: \*/
   attribute_definition:
-    match: (\()?((?!null|false|true)[[:alpha:]][[:alnum:]_-]*)(\))?\s*(\=(?!\=|\>))\s*
+    match: (\()?(\b(?!null\s|false\s|true\s)[[:alpha:]][[:alnum:]_-]*)(\))?\s*(\=(?!\=|\>))\s*
     comment: Identifier "=" with optional parens
     name: variable.declaration.hcl
     captures:
@@ -149,7 +149,7 @@ repository:
       - include: "#string_interpolation"
       - include: "#char_escapes"
   string_interpolation:
-    begin: '(?<![%$])([%$]{)'
+    begin: "(?<![%$])([%$]{)"
     comment: String interpolation
     name: meta.interpolation.hcl
     beginCaptures:

--- a/src/_main.yml
+++ b/src/_main.yml
@@ -58,7 +58,7 @@ repository:
         name: punctuation.definition.comment.hcl
     end: \*/
   attribute_definition:
-    match: (\()?(\b(?!null\s|false\s|true\s)[[:alpha:]][[:alnum:]_-]*)(\))?\s*(\=(?!\=|\>))\s*
+    match: (\()?(\b(?!null\b|false\b|true\b)[[:alpha:]][[:alnum:]_-]*)(\))?\s*(\=(?!\=|\>))\s*
     comment: Identifier "=" with optional parens
     name: variable.declaration.hcl
     captures:

--- a/syntaxes/hcl.tmGrammar.json
+++ b/syntaxes/hcl.tmGrammar.json
@@ -48,7 +48,7 @@
     },
     "attribute_definition": {
       "name": "variable.declaration.hcl",
-      "match": "(\\()?((?!null|false|true)[[:alpha:]][[:alnum:]_-]*)(\\))?\\s*(\\=(?!\\=|\\>))\\s*",
+      "match": "(\\()?(\\b(?!null\\s|false\\s|true\\s)[[:alpha:]][[:alnum:]_-]*)(\\))?\\s*(\\=(?!\\=|\\>))\\s*",
       "comment": "Identifier \"=\" with optional parens",
       "captures": {
         "1": {

--- a/syntaxes/hcl.tmGrammar.json
+++ b/syntaxes/hcl.tmGrammar.json
@@ -48,7 +48,7 @@
     },
     "attribute_definition": {
       "name": "variable.declaration.hcl",
-      "match": "(\\()?(\\b(?!null\\s|false\\s|true\\s)[[:alpha:]][[:alnum:]_-]*)(\\))?\\s*(\\=(?!\\=|\\>))\\s*",
+      "match": "(\\()?(\\b(?!null\\b|false\\b|true\\b)[[:alpha:]][[:alnum:]_-]*)(\\))?\\s*(\\=(?!\\=|\\>))\\s*",
       "comment": "Identifier \"=\" with optional parens",
       "captures": {
         "1": {

--- a/syntaxes/terraform.tmGrammar.json
+++ b/syntaxes/terraform.tmGrammar.json
@@ -49,7 +49,7 @@
     },
     "attribute_definition": {
       "name": "variable.declaration.hcl",
-      "match": "(\\()?(\\b(?!null\\s|false\\s|true\\s)[[:alpha:]][[:alnum:]_-]*)(\\))?\\s*(\\=(?!\\=|\\>))\\s*",
+      "match": "(\\()?(\\b(?!null\\b|false\\b|true\\b)[[:alpha:]][[:alnum:]_-]*)(\\))?\\s*(\\=(?!\\=|\\>))\\s*",
       "comment": "Identifier \"=\" with optional parens",
       "captures": {
         "1": {

--- a/syntaxes/terraform.tmGrammar.json
+++ b/syntaxes/terraform.tmGrammar.json
@@ -49,7 +49,7 @@
     },
     "attribute_definition": {
       "name": "variable.declaration.hcl",
-      "match": "(\\()?((?!null|false|true)[[:alpha:]][[:alnum:]_-]*)(\\))?\\s*(\\=(?!\\=|\\>))\\s*",
+      "match": "(\\()?(\\b(?!null\\s|false\\s|true\\s)[[:alpha:]][[:alnum:]_-]*)(\\))?\\s*(\\=(?!\\=|\\>))\\s*",
       "comment": "Identifier \"=\" with optional parens",
       "captures": {
         "1": {

--- a/tests/snapshot/hcl/issue1286.hcl
+++ b/tests/snapshot/hcl/issue1286.hcl
@@ -1,0 +1,9 @@
+variable "foo" {
+  description = "bar"
+  nullable    = true
+  falseyy     = "bar"
+  trueyy      = "bar"
+  null        = "true"
+  false       = "true"
+  true        = "bar"
+}

--- a/tests/snapshot/hcl/issue1286.hcl
+++ b/tests/snapshot/hcl/issue1286.hcl
@@ -6,4 +6,10 @@ variable "foo" {
   null        = "true"
   false       = "true"
   true        = "bar"
+  nullable=true
+  falseyy=""
+  trueyy=""
+  null=true
+  false=""
+  true=""
 }

--- a/tests/snapshot/hcl/issue1286.hcl.snap
+++ b/tests/snapshot/hcl/issue1286.hcl.snap
@@ -59,6 +59,40 @@
 #                ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
 #                 ^^^ source.hcl meta.block.hcl string.quoted.double.hcl
 #                    ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+>  nullable=true
+#^^ source.hcl meta.block.hcl
+#  ^^^^^^^^ source.hcl meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#          ^ source.hcl meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#           ^^^^ source.hcl meta.block.hcl constant.language.hcl
+>  falseyy=""
+#^^ source.hcl meta.block.hcl
+#  ^^^^^^^ source.hcl meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#         ^ source.hcl meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#          ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#           ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+>  trueyy=""
+#^^ source.hcl meta.block.hcl
+#  ^^^^^^ source.hcl meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#        ^ source.hcl meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#         ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#          ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+>  null=true
+#^^ source.hcl meta.block.hcl
+#  ^^^^ source.hcl meta.block.hcl constant.language.hcl
+#      ^ source.hcl meta.block.hcl
+#       ^^^^ source.hcl meta.block.hcl constant.language.hcl
+>  false=""
+#^^ source.hcl meta.block.hcl
+#  ^^^^^ source.hcl meta.block.hcl constant.language.hcl
+#       ^ source.hcl meta.block.hcl
+#        ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#         ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+>  true=""
+#^^ source.hcl meta.block.hcl
+#  ^^^^ source.hcl meta.block.hcl constant.language.hcl
+#      ^ source.hcl meta.block.hcl
+#       ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#        ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
 >}
 #^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
 >

--- a/tests/snapshot/hcl/issue1286.hcl.snap
+++ b/tests/snapshot/hcl/issue1286.hcl.snap
@@ -1,0 +1,64 @@
+>variable "foo" {
+#^^^^^^^^ source.hcl meta.block.hcl entity.name.type.hcl
+#        ^ source.hcl meta.block.hcl
+#         ^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#              ^ source.hcl meta.block.hcl
+#               ^ source.hcl meta.block.hcl punctuation.section.block.begin.hcl
+>  description = "bar"
+#^^ source.hcl meta.block.hcl
+#  ^^^^^^^^^^^ source.hcl meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#             ^ source.hcl meta.block.hcl variable.declaration.hcl
+#              ^ source.hcl meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#               ^ source.hcl meta.block.hcl variable.declaration.hcl
+#                ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                 ^^^ source.hcl meta.block.hcl string.quoted.double.hcl
+#                    ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+>  nullable    = true
+#^^ source.hcl meta.block.hcl
+#  ^^^^^^^^ source.hcl meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#          ^^^^ source.hcl meta.block.hcl variable.declaration.hcl
+#              ^ source.hcl meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#               ^ source.hcl meta.block.hcl variable.declaration.hcl
+#                ^^^^ source.hcl meta.block.hcl constant.language.hcl
+>  falseyy     = "bar"
+#^^ source.hcl meta.block.hcl
+#  ^^^^^^^ source.hcl meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#         ^^^^^ source.hcl meta.block.hcl variable.declaration.hcl
+#              ^ source.hcl meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#               ^ source.hcl meta.block.hcl variable.declaration.hcl
+#                ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                 ^^^ source.hcl meta.block.hcl string.quoted.double.hcl
+#                    ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+>  trueyy      = "bar"
+#^^ source.hcl meta.block.hcl
+#  ^^^^^^ source.hcl meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#        ^^^^^^ source.hcl meta.block.hcl variable.declaration.hcl
+#              ^ source.hcl meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#               ^ source.hcl meta.block.hcl variable.declaration.hcl
+#                ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                 ^^^ source.hcl meta.block.hcl string.quoted.double.hcl
+#                    ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+>  null        = "true"
+#^^ source.hcl meta.block.hcl
+#  ^^^^ source.hcl meta.block.hcl constant.language.hcl
+#      ^^^^^^^^^^ source.hcl meta.block.hcl
+#                ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                 ^^^^ source.hcl meta.block.hcl string.quoted.double.hcl
+#                     ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+>  false       = "true"
+#^^ source.hcl meta.block.hcl
+#  ^^^^^ source.hcl meta.block.hcl constant.language.hcl
+#       ^^^^^^^^^ source.hcl meta.block.hcl
+#                ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                 ^^^^ source.hcl meta.block.hcl string.quoted.double.hcl
+#                     ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+>  true        = "bar"
+#^^ source.hcl meta.block.hcl
+#  ^^^^ source.hcl meta.block.hcl constant.language.hcl
+#      ^^^^^^^^^^ source.hcl meta.block.hcl
+#                ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                 ^^^ source.hcl meta.block.hcl string.quoted.double.hcl
+#                    ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+>}
+#^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
+>


### PR DESCRIPTION
This PR improves the attribute name matching in two ways:
* We now match a whole word with the negative lookahead instead of just the first letter
* We only match `null`, `false`, and `true` when they are followed by whitespace, so words like `nullable` are matched correctly.

## UX

### Before
<img width="255" alt="CleanShot 2022-12-02 at 15 47 01@2x" src="https://user-images.githubusercontent.com/45985/205335732-f0656d7c-d93d-47bb-b97f-ba62f28c395d.png">

### After
<img width="258" alt="CleanShot 2022-12-02 at 15 45 42@2x" src="https://user-images.githubusercontent.com/45985/205335663-ddac2f82-fc9d-4576-841b-c3e15f49dded.png">

Fixes https://github.com/hashicorp/vscode-terraform/issues/1286