### PR TITLE
github: bump checkout job to v3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
         node-version-file: '.nvmrc'


### PR DESCRIPTION
I'm not sure why this wasn't picked up by dependabot.

Either way, this should address the following warning

![Screenshot 2022-12-09 at 11 14 59](https://user-images.githubusercontent.com/287584/206690363-3c419770-02b1-407b-88a1-4467a5c51131.png)
https://github.com/hashicorp/syntax/actions/runs/3656845023