### PR TITLE
github: Pin external GitHub Actions to hashes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   release:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # https://github.com/actions/checkout/releases/tag/v3.2.0
       - name: GH Release
         run: |
           gh release create "${GITHUB_REF#refs/tags/}" ./syntaxes/*.json --generate-notes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # https://github.com/actions/checkout/releases/tag/v3.2.0
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # https://github.com/actions/setup-node/releases/tag/v3.5.1
       with:
         node-version-file: '.nvmrc'
     - name: Install modules

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # https://github.com/actions/checkout/releases/tag/v3.2.0
     - uses: actions/setup-node@v3
       with:
         node-version-file: '.nvmrc'


### PR DESCRIPTION
The intention here is to reduce the security risk posed by the supply chain - i.e. externally maintained GitHub Actions.

The expectation is that dependabot will continue to update these hashes as and when new versions become available.