### PR TITLE
Be more permissive in allowed characters in a block label

### DIFF
--- a/src/_main.yml
+++ b/src/_main.yml
@@ -76,7 +76,7 @@ repository:
   block:
     name: meta.block.hcl
     comment: This will match HCL blocks like `thing1 "one" "two" {` or `thing2 {`
-    begin: ([\w][\-\w]*)([\s\"\-\w]*)(\{)
+    begin: ([\w][\-\w]*)([^{\r\n]*)(\{)
     beginCaptures:
       "1":
         patterns:
@@ -86,8 +86,11 @@ repository:
       "2":
         patterns:
           - name: variable.other.enummember.hcl
-            comment: Block label
-            match: '[\"\-\w]+'
+            comment: Block label (String Literal)
+            match: '\"[^\"\r\n]*\"'
+          - name: variable.other.enummember.hcl
+            comment: Block label (Indentifier)
+            match: '[[:alpha:]][[:alnum:]_-]*'
       "3":
         name: punctuation.section.block.begin.hcl
     end: \}
@@ -97,8 +100,9 @@ repository:
     patterns:
       - include: "#comments"
       - include: "#attribute_definition"
-      - include: "#block"
       - include: "#expressions"
+      # Order is important and blocks should be last
+      - include: "#block"
   expressions:
     patterns:
       - include: "#literal_values"

--- a/syntaxes/hcl.tmGrammar.json
+++ b/syntaxes/hcl.tmGrammar.json
@@ -82,7 +82,7 @@
     },
     "block": {
       "name": "meta.block.hcl",
-      "begin": "([\\w][\\-\\w]*)([\\s\\\"\\-\\w]*)(\\{)",
+      "begin": "([\\w][\\-\\w]*)([^{\\r\\n]*)(\\{)",
       "end": "\\}",
       "comment": "This will match HCL blocks like `thing1 \"one\" \"two\" {` or `thing2 {`",
       "beginCaptures": {
@@ -98,8 +98,13 @@
         "2": {
           "patterns": [
             {
-              "match": "[\\\"\\-\\w]+",
-              "comment": "Block label",
+              "match": "\\\"[^\\\"\\r\\n]*\\\"",
+              "comment": "Block label (String Literal)",
+              "name": "variable.other.enummember.hcl"
+            },
+            {
+              "match": "[[:alpha:]][[:alnum:]_-]*",
+              "comment": "Block label (Indentifier)",
               "name": "variable.other.enummember.hcl"
             }
           ]
@@ -121,10 +126,10 @@
           "include": "#attribute_definition"
         },
         {
-          "include": "#block"
+          "include": "#expressions"
         },
         {
-          "include": "#expressions"
+          "include": "#block"
         }
       ]
     },

--- a/tests/snapshot/hcl/block_labels.hcl
+++ b/tests/snapshot/hcl/block_labels.hcl
@@ -36,3 +36,12 @@ blocklabelmixed-newline "foo" bar "loru" m-ipsum {
 blockutf8 "foož:/ᚠᚢ" {}
 blockutf8-newline "foož:/ᚠᚢ" {
 }
+
+// edgecases
+blockempty "" {}
+blockempty-newline "" {
+}
+
+block-single-char-indentifier a {}
+block-single-char-indentifier-newline a {
+}

--- a/tests/snapshot/hcl/block_labels.hcl
+++ b/tests/snapshot/hcl/block_labels.hcl
@@ -1,0 +1,38 @@
+// generic blocks with multiple labels as strings
+block0 {}
+block0-newline {
+}
+
+block1 "foo" {}
+block1-newline "foo" {
+}
+
+block2 "foo" "bar" {}
+block2-newline "foo" "bar" {
+}
+
+block3 "foo" "bar" "baz" {}
+block3-newline "foo" "bar" "baz" {
+}
+
+block4 "foo" "bar" "baz" "lorum" {}
+block4-newline "foo" "bar" "baz" "lorum" {
+}
+
+block5 "foo" "bar" "baz" "lorum" "ipsum" {}
+block5-newline "foo" "bar" "baz" "lorum" "ipsum" {
+}
+
+// generic blocks with indentifier labels
+blocklabel1 foo bar lorum-ipsum {}
+blocklabel1-newline foo bar lorum-ipsum {
+}
+
+blocklabelmixed "foo" bar "loru" m-ipsum {}
+blocklabelmixed-newline "foo" bar "loru" m-ipsum {
+}
+
+// utf8 labels
+blockutf8 "foož:/ᚠᚢ" {}
+blockutf8-newline "foož:/ᚠᚢ" {
+}

--- a/tests/snapshot/hcl/block_labels.hcl.snap
+++ b/tests/snapshot/hcl/block_labels.hcl.snap
@@ -1,0 +1,209 @@
+>// generic blocks with multiple labels as strings
+#^^ source.hcl comment.line.double-slash.hcl punctuation.definition.comment.hcl
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl comment.line.double-slash.hcl
+>block0 {}
+#^^^^^^ source.hcl meta.block.hcl entity.name.type.hcl
+#      ^ source.hcl meta.block.hcl
+#       ^ source.hcl meta.block.hcl punctuation.section.block.begin.hcl
+#        ^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
+>block0-newline {
+#^^^^^^^^^^^^^^ source.hcl meta.block.hcl entity.name.type.hcl
+#              ^ source.hcl meta.block.hcl
+#               ^ source.hcl meta.block.hcl punctuation.section.block.begin.hcl
+>}
+#^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
+>
+>block1 "foo" {}
+#^^^^^^ source.hcl meta.block.hcl entity.name.type.hcl
+#      ^ source.hcl meta.block.hcl
+#       ^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#            ^ source.hcl meta.block.hcl
+#             ^ source.hcl meta.block.hcl punctuation.section.block.begin.hcl
+#              ^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
+>block1-newline "foo" {
+#^^^^^^^^^^^^^^ source.hcl meta.block.hcl entity.name.type.hcl
+#              ^ source.hcl meta.block.hcl
+#               ^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                    ^ source.hcl meta.block.hcl
+#                     ^ source.hcl meta.block.hcl punctuation.section.block.begin.hcl
+>}
+#^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
+>
+>block2 "foo" "bar" {}
+#^^^^^^ source.hcl meta.block.hcl entity.name.type.hcl
+#      ^ source.hcl meta.block.hcl
+#       ^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#            ^ source.hcl meta.block.hcl
+#             ^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                  ^ source.hcl meta.block.hcl
+#                   ^ source.hcl meta.block.hcl punctuation.section.block.begin.hcl
+#                    ^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
+>block2-newline "foo" "bar" {
+#^^^^^^^^^^^^^^ source.hcl meta.block.hcl entity.name.type.hcl
+#              ^ source.hcl meta.block.hcl
+#               ^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                    ^ source.hcl meta.block.hcl
+#                     ^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                          ^ source.hcl meta.block.hcl
+#                           ^ source.hcl meta.block.hcl punctuation.section.block.begin.hcl
+>}
+#^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
+>
+>block3 "foo" "bar" "baz" {}
+#^^^^^^ source.hcl meta.block.hcl entity.name.type.hcl
+#      ^ source.hcl meta.block.hcl
+#       ^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#            ^ source.hcl meta.block.hcl
+#             ^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                  ^ source.hcl meta.block.hcl
+#                   ^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                        ^ source.hcl meta.block.hcl
+#                         ^ source.hcl meta.block.hcl punctuation.section.block.begin.hcl
+#                          ^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
+>block3-newline "foo" "bar" "baz" {
+#^^^^^^^^^^^^^^ source.hcl meta.block.hcl entity.name.type.hcl
+#              ^ source.hcl meta.block.hcl
+#               ^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                    ^ source.hcl meta.block.hcl
+#                     ^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                          ^ source.hcl meta.block.hcl
+#                           ^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                                ^ source.hcl meta.block.hcl
+#                                 ^ source.hcl meta.block.hcl punctuation.section.block.begin.hcl
+>}
+#^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
+>
+>block4 "foo" "bar" "baz" "lorum" {}
+#^^^^^^ source.hcl meta.block.hcl entity.name.type.hcl
+#      ^ source.hcl meta.block.hcl
+#       ^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#            ^ source.hcl meta.block.hcl
+#             ^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                  ^ source.hcl meta.block.hcl
+#                   ^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                        ^ source.hcl meta.block.hcl
+#                         ^^^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                                ^ source.hcl meta.block.hcl
+#                                 ^ source.hcl meta.block.hcl punctuation.section.block.begin.hcl
+#                                  ^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
+>block4-newline "foo" "bar" "baz" "lorum" {
+#^^^^^^^^^^^^^^ source.hcl meta.block.hcl entity.name.type.hcl
+#              ^ source.hcl meta.block.hcl
+#               ^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                    ^ source.hcl meta.block.hcl
+#                     ^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                          ^ source.hcl meta.block.hcl
+#                           ^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                                ^ source.hcl meta.block.hcl
+#                                 ^^^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                                        ^ source.hcl meta.block.hcl
+#                                         ^ source.hcl meta.block.hcl punctuation.section.block.begin.hcl
+>}
+#^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
+>
+>block5 "foo" "bar" "baz" "lorum" "ipsum" {}
+#^^^^^^ source.hcl meta.block.hcl entity.name.type.hcl
+#      ^ source.hcl meta.block.hcl
+#       ^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#            ^ source.hcl meta.block.hcl
+#             ^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                  ^ source.hcl meta.block.hcl
+#                   ^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                        ^ source.hcl meta.block.hcl
+#                         ^^^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                                ^ source.hcl meta.block.hcl
+#                                 ^^^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                                        ^ source.hcl meta.block.hcl
+#                                         ^ source.hcl meta.block.hcl punctuation.section.block.begin.hcl
+#                                          ^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
+>block5-newline "foo" "bar" "baz" "lorum" "ipsum" {
+#^^^^^^^^^^^^^^ source.hcl meta.block.hcl entity.name.type.hcl
+#              ^ source.hcl meta.block.hcl
+#               ^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                    ^ source.hcl meta.block.hcl
+#                     ^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                          ^ source.hcl meta.block.hcl
+#                           ^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                                ^ source.hcl meta.block.hcl
+#                                 ^^^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                                        ^ source.hcl meta.block.hcl
+#                                         ^^^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                                                ^ source.hcl meta.block.hcl
+#                                                 ^ source.hcl meta.block.hcl punctuation.section.block.begin.hcl
+>}
+#^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
+>
+>// generic blocks with indentifier labels
+#^^ source.hcl comment.line.double-slash.hcl punctuation.definition.comment.hcl
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl comment.line.double-slash.hcl
+>blocklabel1 foo bar lorum-ipsum {}
+#^^^^^^^^^^^ source.hcl meta.block.hcl entity.name.type.hcl
+#           ^ source.hcl meta.block.hcl
+#            ^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#               ^ source.hcl meta.block.hcl
+#                ^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                   ^ source.hcl meta.block.hcl
+#                    ^^^^^^^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                               ^ source.hcl meta.block.hcl
+#                                ^ source.hcl meta.block.hcl punctuation.section.block.begin.hcl
+#                                 ^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
+>blocklabel1-newline foo bar lorum-ipsum {
+#^^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl entity.name.type.hcl
+#                   ^ source.hcl meta.block.hcl
+#                    ^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                       ^ source.hcl meta.block.hcl
+#                        ^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                           ^ source.hcl meta.block.hcl
+#                            ^^^^^^^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                                       ^ source.hcl meta.block.hcl
+#                                        ^ source.hcl meta.block.hcl punctuation.section.block.begin.hcl
+>}
+#^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
+>
+>blocklabelmixed "foo" bar "loru" m-ipsum {}
+#^^^^^^^^^^^^^^^ source.hcl meta.block.hcl entity.name.type.hcl
+#               ^ source.hcl meta.block.hcl
+#                ^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                     ^ source.hcl meta.block.hcl
+#                      ^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                         ^ source.hcl meta.block.hcl
+#                          ^^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                                ^ source.hcl meta.block.hcl
+#                                 ^^^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                                        ^ source.hcl meta.block.hcl
+#                                         ^ source.hcl meta.block.hcl punctuation.section.block.begin.hcl
+#                                          ^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
+>blocklabelmixed-newline "foo" bar "loru" m-ipsum {
+#^^^^^^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl entity.name.type.hcl
+#                       ^ source.hcl meta.block.hcl
+#                        ^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                             ^ source.hcl meta.block.hcl
+#                              ^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                                 ^ source.hcl meta.block.hcl
+#                                  ^^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                                        ^ source.hcl meta.block.hcl
+#                                         ^^^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                                                ^ source.hcl meta.block.hcl
+#                                                 ^ source.hcl meta.block.hcl punctuation.section.block.begin.hcl
+>}
+#^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
+>
+>// utf8 labels
+#^^ source.hcl comment.line.double-slash.hcl punctuation.definition.comment.hcl
+#  ^^^^^^^^^^^^ source.hcl comment.line.double-slash.hcl
+>blockutf8 "foož:/ᚠᚢ" {}
+#^^^^^^^^^ source.hcl meta.block.hcl entity.name.type.hcl
+#         ^ source.hcl meta.block.hcl
+#          ^^^^^^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                    ^ source.hcl meta.block.hcl
+#                     ^ source.hcl meta.block.hcl punctuation.section.block.begin.hcl
+#                      ^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
+>blockutf8-newline "foož:/ᚠᚢ" {
+#^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl entity.name.type.hcl
+#                 ^ source.hcl meta.block.hcl
+#                  ^^^^^^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                            ^ source.hcl meta.block.hcl
+#                             ^ source.hcl meta.block.hcl punctuation.section.block.begin.hcl
+>}
+#^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
+>

--- a/tests/snapshot/hcl/block_labels.hcl.snap
+++ b/tests/snapshot/hcl/block_labels.hcl.snap
@@ -207,3 +207,38 @@
 >}
 #^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
 >
+>// edgecases
+#^^ source.hcl comment.line.double-slash.hcl punctuation.definition.comment.hcl
+#  ^^^^^^^^^^ source.hcl comment.line.double-slash.hcl
+>blockempty "" {}
+#^^^^^^^^^^ source.hcl meta.block.hcl entity.name.type.hcl
+#          ^ source.hcl meta.block.hcl
+#           ^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#             ^ source.hcl meta.block.hcl
+#              ^ source.hcl meta.block.hcl punctuation.section.block.begin.hcl
+#               ^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
+>blockempty-newline "" {
+#^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl entity.name.type.hcl
+#                  ^ source.hcl meta.block.hcl
+#                   ^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                     ^ source.hcl meta.block.hcl
+#                      ^ source.hcl meta.block.hcl punctuation.section.block.begin.hcl
+>}
+#^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
+>
+>block-single-char-indentifier a {}
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl entity.name.type.hcl
+#                             ^ source.hcl meta.block.hcl
+#                              ^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                               ^ source.hcl meta.block.hcl
+#                                ^ source.hcl meta.block.hcl punctuation.section.block.begin.hcl
+#                                 ^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
+>block-single-char-indentifier-newline a {
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl entity.name.type.hcl
+#                                     ^ source.hcl meta.block.hcl
+#                                      ^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                                       ^ source.hcl meta.block.hcl
+#                                        ^ source.hcl meta.block.hcl punctuation.section.block.begin.hcl
+>}
+#^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
+>

--- a/tests/snapshot/hcl/block_nested_complex.hcl
+++ b/tests/snapshot/hcl/block_nested_complex.hcl
@@ -1,0 +1,21 @@
+resource "aws_instance" "web" {
+  // The trailing { can confuse the regex into thinking it's a block
+  type = list(object({
+    internal = number
+    external = number
+    protocol = string
+  }))
+
+// The trailing { can confuse the regex into thinking it's a block
+  default = [{
+      internal = 8300
+      external = 8300
+      protocol = "tcp"
+    }
+  ]
+
+  # This is a nested block and should highlight correctly
+  nested-resource "aws_instance" "foo" {
+    type = "nested"
+  }
+}

--- a/tests/snapshot/hcl/block_nested_complex.hcl.snap
+++ b/tests/snapshot/hcl/block_nested_complex.hcl.snap
@@ -1,0 +1,119 @@
+>resource "aws_instance" "web" {
+#^^^^^^^^ source.hcl meta.block.hcl entity.name.type.hcl
+#        ^ source.hcl meta.block.hcl
+#         ^^^^^^^^^^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                       ^ source.hcl meta.block.hcl
+#                        ^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                             ^ source.hcl meta.block.hcl
+#                              ^ source.hcl meta.block.hcl punctuation.section.block.begin.hcl
+>  // The trailing { can confuse the regex into thinking it's a block
+#^^ source.hcl meta.block.hcl
+#  ^^ source.hcl meta.block.hcl comment.line.double-slash.hcl punctuation.definition.comment.hcl
+#    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl comment.line.double-slash.hcl
+>  type = list(object({
+#^^ source.hcl meta.block.hcl
+#  ^^^^ source.hcl meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#      ^ source.hcl meta.block.hcl variable.declaration.hcl
+#       ^ source.hcl meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#        ^ source.hcl meta.block.hcl variable.declaration.hcl
+#         ^^^^ source.hcl meta.block.hcl storage.type.hcl
+#             ^ source.hcl meta.block.hcl punctuation.section.parens.begin.hcl
+#              ^^^^^^ source.hcl meta.block.hcl storage.type.hcl
+#                    ^ source.hcl meta.block.hcl punctuation.section.parens.begin.hcl
+#                     ^ source.hcl meta.block.hcl meta.braces.hcl punctuation.section.braces.begin.hcl
+>    internal = number
+#^^^^ source.hcl meta.block.hcl meta.braces.hcl
+#    ^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
+#            ^ source.hcl meta.block.hcl meta.braces.hcl
+#             ^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.assignment.hcl
+#              ^ source.hcl meta.block.hcl meta.braces.hcl
+#               ^^^^^^ source.hcl meta.block.hcl meta.braces.hcl storage.type.hcl
+>    external = number
+#^^^^ source.hcl meta.block.hcl meta.braces.hcl
+#    ^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
+#            ^ source.hcl meta.block.hcl meta.braces.hcl
+#             ^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.assignment.hcl
+#              ^ source.hcl meta.block.hcl meta.braces.hcl
+#               ^^^^^^ source.hcl meta.block.hcl meta.braces.hcl storage.type.hcl
+>    protocol = string
+#^^^^ source.hcl meta.block.hcl meta.braces.hcl
+#    ^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
+#            ^ source.hcl meta.block.hcl meta.braces.hcl
+#             ^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.assignment.hcl
+#              ^ source.hcl meta.block.hcl meta.braces.hcl
+#               ^^^^^^ source.hcl meta.block.hcl meta.braces.hcl storage.type.hcl
+>  }))
+#^^ source.hcl meta.block.hcl meta.braces.hcl
+#  ^ source.hcl meta.block.hcl meta.braces.hcl punctuation.section.braces.end.hcl
+#   ^ source.hcl meta.block.hcl punctuation.section.parens.end.hcl
+#    ^ source.hcl meta.block.hcl punctuation.section.parens.end.hcl
+>
+>// The trailing { can confuse the regex into thinking it's a block
+#^^ source.hcl meta.block.hcl comment.line.double-slash.hcl punctuation.definition.comment.hcl
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl comment.line.double-slash.hcl
+>  default = [{
+#^^ source.hcl meta.block.hcl
+#  ^^^^^^^ source.hcl meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#         ^ source.hcl meta.block.hcl variable.declaration.hcl
+#          ^ source.hcl meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#           ^ source.hcl meta.block.hcl variable.declaration.hcl
+#            ^ source.hcl meta.block.hcl punctuation.section.brackets.begin.hcl
+#             ^ source.hcl meta.block.hcl meta.braces.hcl punctuation.section.braces.begin.hcl
+>      internal = 8300
+#^^^^^^ source.hcl meta.block.hcl meta.braces.hcl
+#      ^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
+#              ^ source.hcl meta.block.hcl meta.braces.hcl
+#               ^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.assignment.hcl
+#                ^ source.hcl meta.block.hcl meta.braces.hcl
+#                 ^^^^ source.hcl meta.block.hcl meta.braces.hcl constant.numeric.integer.hcl
+>      external = 8300
+#^^^^^^ source.hcl meta.block.hcl meta.braces.hcl
+#      ^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
+#              ^ source.hcl meta.block.hcl meta.braces.hcl
+#               ^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.assignment.hcl
+#                ^ source.hcl meta.block.hcl meta.braces.hcl
+#                 ^^^^ source.hcl meta.block.hcl meta.braces.hcl constant.numeric.integer.hcl
+>      protocol = "tcp"
+#^^^^^^ source.hcl meta.block.hcl meta.braces.hcl
+#      ^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
+#              ^ source.hcl meta.block.hcl meta.braces.hcl
+#               ^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.assignment.hcl
+#                ^ source.hcl meta.block.hcl meta.braces.hcl
+#                 ^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                  ^^^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl
+#                     ^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+>    }
+#^^^^ source.hcl meta.block.hcl meta.braces.hcl
+#    ^ source.hcl meta.block.hcl meta.braces.hcl punctuation.section.braces.end.hcl
+>  ]
+#^^ source.hcl meta.block.hcl
+#  ^ source.hcl meta.block.hcl punctuation.section.brackets.end.hcl
+>
+>  # This is a nested block and should highlight correctly
+#^^ source.hcl meta.block.hcl
+#  ^ source.hcl meta.block.hcl comment.line.number-sign.hcl punctuation.definition.comment.hcl
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl comment.line.number-sign.hcl
+>  nested-resource "aws_instance" "foo" {
+#^^ source.hcl meta.block.hcl
+#  ^^^^^^^^^^^^^^^ source.hcl meta.block.hcl meta.block.hcl entity.name.type.hcl
+#                 ^ source.hcl meta.block.hcl meta.block.hcl
+#                  ^^^^^^^^^^^^^^ source.hcl meta.block.hcl meta.block.hcl variable.other.enummember.hcl
+#                                ^ source.hcl meta.block.hcl meta.block.hcl
+#                                 ^^^^^ source.hcl meta.block.hcl meta.block.hcl variable.other.enummember.hcl
+#                                      ^ source.hcl meta.block.hcl meta.block.hcl
+#                                       ^ source.hcl meta.block.hcl meta.block.hcl punctuation.section.block.begin.hcl
+>    type = "nested"
+#^^^^ source.hcl meta.block.hcl meta.block.hcl
+#    ^^^^ source.hcl meta.block.hcl meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#        ^ source.hcl meta.block.hcl meta.block.hcl variable.declaration.hcl
+#         ^ source.hcl meta.block.hcl meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#          ^ source.hcl meta.block.hcl meta.block.hcl variable.declaration.hcl
+#           ^ source.hcl meta.block.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#            ^^^^^^ source.hcl meta.block.hcl meta.block.hcl string.quoted.double.hcl
+#                  ^ source.hcl meta.block.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+>  }
+#^^ source.hcl meta.block.hcl meta.block.hcl
+#  ^ source.hcl meta.block.hcl meta.block.hcl punctuation.section.block.end.hcl
+>}
+#^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
+>


### PR DESCRIPTION
Fixes #93 

Previously a block label would only be allowed to contain the set of characters in an Identifier, however a block label string literal can contain pretty much any character. This commit updates the base HCL grammar to support both identifiers and string literals in block labels and adds tests to ensure this behaviour works as expected.

* This PR also fixes up the grammar because it would match block labels that spanned lines, whereas the language spec doesn't allow that

* This PR doesn't solve the issue of a brace or a double quote being _in_ a string literal;  e.g. `blockname "foo\{" {` or `blockname "foo\"bar" {` would do weird highlighting. However, this PR is still much better at highlighting than the current code.