### PR TITLE
feat: support provider defined functions for Terraform HCL

### DIFF
--- a/src/terraform.yml
+++ b/src/terraform.yml
@@ -39,7 +39,7 @@ repository:
       - include: "#expressions"
 
   functions:
-    begin: (\w+|(?:provider::\w+::\w+))(\()
+    begin: ([:\-\w]+)(\()
     name: meta.function-call.hcl
     comment: Built-in function calls
     beginCaptures:
@@ -47,7 +47,7 @@ repository:
         patterns:
           - match: \b(abs|abspath|alltrue|anytrue|base64decode|base64encode|base64gzip|base64sha256|base64sha512|basename|bcrypt|can|ceil|chomp|chunklist|cidrhost|cidrnetmask|cidrsubnet|cidrsubnets|coalesce|coalescelist|compact|concat|contains|csvdecode|dirname|distinct|element|endswith|file|filebase64|filebase64sha256|filebase64sha512|fileexists|filemd5|fileset|filesha1|filesha256|filesha512|flatten|floor|format|formatdate|formatlist|indent|index|join|jsondecode|jsonencode|keys|length|log|lookup|lower|matchkeys|max|md5|merge|min|nonsensitive|one|parseint|pathexpand|plantimestamp|pow|range|regex|regexall|replace|reverse|rsadecrypt|sensitive|setintersection|setproduct|setsubtract|setunion|sha1|sha256|sha512|signum|slice|sort|split|startswith|strcontains|strrev|substr|sum|templatefile|textdecodebase64|textencodebase64|timeadd|timecmp|timestamp|title|tobool|tolist|tomap|tonumber|toset|tostring|transpose|trim|trimprefix|trimspace|trimsuffix|try|upper|urlencode|uuid|uuidv5|values|yamldecode|yamlencode|zipmap)\b
             name: support.function.builtin.terraform
-          - match: \bprovider::(?!null|false|true)[[:alpha:]][[:alnum:]_-]*::(?!null|false|true)[[:alpha:]][[:alnum:]_-]*\b
+          - match: \bprovider::(?!false|true)\w*::(?!null|false|true)\w*\b
             name: support.function.provider
       "2":
         name: punctuation.section.parens.begin.hcl

--- a/src/terraform.yml
+++ b/src/terraform.yml
@@ -39,7 +39,7 @@ repository:
       - include: "#expressions"
 
   functions:
-    begin: (\w+)(\()
+    begin: (\w+|(?:provider::\w+::\w+))(\()
     name: meta.function-call.hcl
     comment: Built-in function calls
     beginCaptures:
@@ -47,6 +47,8 @@ repository:
         patterns:
           - match: \b(abs|abspath|alltrue|anytrue|base64decode|base64encode|base64gzip|base64sha256|base64sha512|basename|bcrypt|can|ceil|chomp|chunklist|cidrhost|cidrnetmask|cidrsubnet|cidrsubnets|coalesce|coalescelist|compact|concat|contains|csvdecode|dirname|distinct|element|endswith|file|filebase64|filebase64sha256|filebase64sha512|fileexists|filemd5|fileset|filesha1|filesha256|filesha512|flatten|floor|format|formatdate|formatlist|indent|index|join|jsondecode|jsonencode|keys|length|log|lookup|lower|matchkeys|max|md5|merge|min|nonsensitive|one|parseint|pathexpand|plantimestamp|pow|range|regex|regexall|replace|reverse|rsadecrypt|sensitive|setintersection|setproduct|setsubtract|setunion|sha1|sha256|sha512|signum|slice|sort|split|startswith|strcontains|strrev|substr|sum|templatefile|textdecodebase64|textencodebase64|timeadd|timecmp|timestamp|title|tobool|tolist|tomap|tonumber|toset|tostring|transpose|trim|trimprefix|trimspace|trimsuffix|try|upper|urlencode|uuid|uuidv5|values|yamldecode|yamlencode|zipmap)\b
             name: support.function.builtin.terraform
+          - match: \bprovider::(?!null|false|true)[[:alpha:]][[:alnum:]_-]*::(?!null|false|true)[[:alpha:]][[:alnum:]_-]*\b
+            name: support.function.provider
       "2":
         name: punctuation.section.parens.begin.hcl
     end: \)

--- a/src/terraform.yml
+++ b/src/terraform.yml
@@ -47,7 +47,7 @@ repository:
         patterns:
           - match: \b(abs|abspath|alltrue|anytrue|base64decode|base64encode|base64gzip|base64sha256|base64sha512|basename|bcrypt|can|ceil|chomp|chunklist|cidrhost|cidrnetmask|cidrsubnet|cidrsubnets|coalesce|coalescelist|compact|concat|contains|csvdecode|dirname|distinct|element|endswith|file|filebase64|filebase64sha256|filebase64sha512|fileexists|filemd5|fileset|filesha1|filesha256|filesha512|flatten|floor|format|formatdate|formatlist|indent|index|join|jsondecode|jsonencode|keys|length|log|lookup|lower|matchkeys|max|md5|merge|min|nonsensitive|one|parseint|pathexpand|plantimestamp|pow|range|regex|regexall|replace|reverse|rsadecrypt|sensitive|setintersection|setproduct|setsubtract|setunion|sha1|sha256|sha512|signum|slice|sort|split|startswith|strcontains|strrev|substr|sum|templatefile|textdecodebase64|textencodebase64|timeadd|timecmp|timestamp|title|tobool|tolist|tomap|tonumber|toset|tostring|transpose|trim|trimprefix|trimspace|trimsuffix|try|upper|urlencode|uuid|uuidv5|values|yamldecode|yamlencode|zipmap)\b
             name: support.function.builtin.terraform
-          - match: \bprovider::[^\d\W][\w_-]*::[^\d\W][\w_-]*\b
+          - match: \bprovider::[[:alpha:]][\w_-]*::[[:alpha:]][\w_-]*\b
             name: support.function.provider
       "2":
         name: punctuation.section.parens.begin.hcl

--- a/src/terraform.yml
+++ b/src/terraform.yml
@@ -47,7 +47,7 @@ repository:
         patterns:
           - match: \b(abs|abspath|alltrue|anytrue|base64decode|base64encode|base64gzip|base64sha256|base64sha512|basename|bcrypt|can|ceil|chomp|chunklist|cidrhost|cidrnetmask|cidrsubnet|cidrsubnets|coalesce|coalescelist|compact|concat|contains|csvdecode|dirname|distinct|element|endswith|file|filebase64|filebase64sha256|filebase64sha512|fileexists|filemd5|fileset|filesha1|filesha256|filesha512|flatten|floor|format|formatdate|formatlist|indent|index|join|jsondecode|jsonencode|keys|length|log|lookup|lower|matchkeys|max|md5|merge|min|nonsensitive|one|parseint|pathexpand|plantimestamp|pow|range|regex|regexall|replace|reverse|rsadecrypt|sensitive|setintersection|setproduct|setsubtract|setunion|sha1|sha256|sha512|signum|slice|sort|split|startswith|strcontains|strrev|substr|sum|templatefile|textdecodebase64|textencodebase64|timeadd|timecmp|timestamp|title|tobool|tolist|tomap|tonumber|toset|tostring|transpose|trim|trimprefix|trimspace|trimsuffix|try|upper|urlencode|uuid|uuidv5|values|yamldecode|yamlencode|zipmap)\b
             name: support.function.builtin.terraform
-          - match: \bprovider::(?!false|true)\w*::(?!null|false|true)\w*\b
+          - match: \bprovider::(?!false|true)[^\d\W][\w_-]*::(?!null|false|true)[^\d\W][\w_-]*\b
             name: support.function.provider
       "2":
         name: punctuation.section.parens.begin.hcl

--- a/src/terraform.yml
+++ b/src/terraform.yml
@@ -47,7 +47,7 @@ repository:
         patterns:
           - match: \b(abs|abspath|alltrue|anytrue|base64decode|base64encode|base64gzip|base64sha256|base64sha512|basename|bcrypt|can|ceil|chomp|chunklist|cidrhost|cidrnetmask|cidrsubnet|cidrsubnets|coalesce|coalescelist|compact|concat|contains|csvdecode|dirname|distinct|element|endswith|file|filebase64|filebase64sha256|filebase64sha512|fileexists|filemd5|fileset|filesha1|filesha256|filesha512|flatten|floor|format|formatdate|formatlist|indent|index|join|jsondecode|jsonencode|keys|length|log|lookup|lower|matchkeys|max|md5|merge|min|nonsensitive|one|parseint|pathexpand|plantimestamp|pow|range|regex|regexall|replace|reverse|rsadecrypt|sensitive|setintersection|setproduct|setsubtract|setunion|sha1|sha256|sha512|signum|slice|sort|split|startswith|strcontains|strrev|substr|sum|templatefile|textdecodebase64|textencodebase64|timeadd|timecmp|timestamp|title|tobool|tolist|tomap|tonumber|toset|tostring|transpose|trim|trimprefix|trimspace|trimsuffix|try|upper|urlencode|uuid|uuidv5|values|yamldecode|yamlencode|zipmap)\b
             name: support.function.builtin.terraform
-          - match: \bprovider::(?!false|true)[^\d\W][\w_-]*::(?!null|false|true)[^\d\W][\w_-]*\b
+          - match: \bprovider::[^\d\W][\w_-]*::[^\d\W][\w_-]*\b
             name: support.function.provider
       "2":
         name: punctuation.section.parens.begin.hcl

--- a/syntaxes/terraform.tmGrammar.json
+++ b/syntaxes/terraform.tmGrammar.json
@@ -295,7 +295,7 @@
               "name": "support.function.builtin.terraform"
             },
             {
-              "match": "\\bprovider::[^\\d\\W][\\w_-]*::[^\\d\\W][\\w_-]*\\b",
+              "match": "\\bprovider::[[:alpha:]][\\w_-]*::[[:alpha:]][\\w_-]*\\b",
               "name": "support.function.provider"
             }
           ]

--- a/syntaxes/terraform.tmGrammar.json
+++ b/syntaxes/terraform.tmGrammar.json
@@ -284,7 +284,7 @@
     },
     "functions": {
       "name": "meta.function-call.hcl",
-      "begin": "(\\w+|(?:provider::\\w+::\\w+))(\\()",
+      "begin": "([:\\-\\w]+)(\\()",
       "end": "\\)",
       "comment": "Built-in function calls",
       "beginCaptures": {
@@ -295,7 +295,7 @@
               "name": "support.function.builtin.terraform"
             },
             {
-              "match": "\\bprovider::(?!null|false|true)[[:alpha:]][[:alnum:]_-]*::(?!null|false|true)[[:alpha:]][[:alnum:]_-]*\\b",
+              "match": "\\bprovider::(?!false|true)[^\\d\\W][\\w_-]*::(?!null|false|true)[^\\d\\W][\\w_-]*\\b",
               "name": "support.function.provider"
             }
           ]

--- a/syntaxes/terraform.tmGrammar.json
+++ b/syntaxes/terraform.tmGrammar.json
@@ -295,7 +295,7 @@
               "name": "support.function.builtin.terraform"
             },
             {
-              "match": "\\bprovider::(?!false|true)[^\\d\\W][\\w_-]*::(?!null|false|true)[^\\d\\W][\\w_-]*\\b",
+              "match": "\\bprovider::[^\\d\\W][\\w_-]*::[^\\d\\W][\\w_-]*\\b",
               "name": "support.function.provider"
             }
           ]

--- a/syntaxes/terraform.tmGrammar.json
+++ b/syntaxes/terraform.tmGrammar.json
@@ -284,7 +284,7 @@
     },
     "functions": {
       "name": "meta.function-call.hcl",
-      "begin": "(\\w+)(\\()",
+      "begin": "(\\w+|(?:provider::\\w+::\\w+))(\\()",
       "end": "\\)",
       "comment": "Built-in function calls",
       "beginCaptures": {
@@ -293,6 +293,10 @@
             {
               "match": "\\b(abs|abspath|alltrue|anytrue|base64decode|base64encode|base64gzip|base64sha256|base64sha512|basename|bcrypt|can|ceil|chomp|chunklist|cidrhost|cidrnetmask|cidrsubnet|cidrsubnets|coalesce|coalescelist|compact|concat|contains|csvdecode|dirname|distinct|element|endswith|file|filebase64|filebase64sha256|filebase64sha512|fileexists|filemd5|fileset|filesha1|filesha256|filesha512|flatten|floor|format|formatdate|formatlist|indent|index|join|jsondecode|jsonencode|keys|length|log|lookup|lower|matchkeys|max|md5|merge|min|nonsensitive|one|parseint|pathexpand|plantimestamp|pow|range|regex|regexall|replace|reverse|rsadecrypt|sensitive|setintersection|setproduct|setsubtract|setunion|sha1|sha256|sha512|signum|slice|sort|split|startswith|strcontains|strrev|substr|sum|templatefile|textdecodebase64|textencodebase64|timeadd|timecmp|timestamp|title|tobool|tolist|tomap|tonumber|toset|tostring|transpose|trim|trimprefix|trimspace|trimsuffix|try|upper|urlencode|uuid|uuidv5|values|yamldecode|yamlencode|zipmap)\\b",
               "name": "support.function.builtin.terraform"
+            },
+            {
+              "match": "\\bprovider::(?!null|false|true)[[:alpha:]][[:alnum:]_-]*::(?!null|false|true)[[:alpha:]][[:alnum:]_-]*\\b",
+              "name": "support.function.provider"
             }
           ]
         },

--- a/tests/snapshot/terraform/expressions_functions.tf
+++ b/tests/snapshot/terraform/expressions_functions.tf
@@ -35,3 +35,8 @@ upper("hello")
 # known
 
 foo("bar")
+
+# provider defined functions
+
+provider::framework::example("hi")
+invalid::namespaced::function("bye")

--- a/tests/snapshot/terraform/expressions_functions.tf.snap
+++ b/tests/snapshot/terraform/expressions_functions.tf.snap
@@ -357,3 +357,28 @@
 #        ^ source.hcl.terraform meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
 #         ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.end.hcl
 >
+># provider defined functions
+#^ source.hcl.terraform comment.line.number-sign.hcl punctuation.definition.comment.hcl
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl.terraform comment.line.number-sign.hcl
+>
+>provider::framework::example("hi")
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl.terraform meta.function-call.hcl support.function.provider
+#                            ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.begin.hcl
+#                             ^ source.hcl.terraform meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                              ^^ source.hcl.terraform meta.function-call.hcl string.quoted.double.hcl
+#                                ^ source.hcl.terraform meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                                 ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.end.hcl
+>invalid::namespaced::function("bye")
+#^^^^^^^ source.hcl.terraform
+#       ^ source.hcl.terraform
+#        ^ source.hcl.terraform
+#         ^^^^^^^^^^ source.hcl.terraform
+#                   ^ source.hcl.terraform
+#                    ^ source.hcl.terraform
+#                     ^^^^^^^^ source.hcl.terraform meta.function-call.hcl
+#                             ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.begin.hcl
+#                              ^ source.hcl.terraform meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                               ^^^ source.hcl.terraform meta.function-call.hcl string.quoted.double.hcl
+#                                  ^ source.hcl.terraform meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                                   ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.end.hcl
+>

--- a/tests/snapshot/terraform/expressions_functions.tf.snap
+++ b/tests/snapshot/terraform/expressions_functions.tf.snap
@@ -369,13 +369,7 @@
 #                                ^ source.hcl.terraform meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
 #                                 ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.end.hcl
 >invalid::namespaced::function("bye")
-#^^^^^^^ source.hcl.terraform
-#       ^ source.hcl.terraform
-#        ^ source.hcl.terraform
-#         ^^^^^^^^^^ source.hcl.terraform
-#                   ^ source.hcl.terraform
-#                    ^ source.hcl.terraform
-#                     ^^^^^^^^ source.hcl.terraform meta.function-call.hcl
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl.terraform meta.function-call.hcl
 #                             ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.begin.hcl
 #                              ^ source.hcl.terraform meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
 #                               ^^^ source.hcl.terraform meta.function-call.hcl string.quoted.double.hcl


### PR DESCRIPTION
This adds support for provider defined functions (e.g. `provider::framework::example("hi")`) to the Terraform HCL syntax.

Resolves #98