### PR TITLE
feat: self update if there have been changes to the grammar but it was not built locally

### DIFF
--- a/.github/workflows/pulls.yml
+++ b/.github/workflows/pulls.yml
@@ -1,0 +1,88 @@
+name: Test All Grammar
+
+on:
+  pull_request:
+    branches:
+      - "main"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      self_mutation_happened: ${{ steps.self_mutation.outputs.self_mutation_happened }}
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version-file: '.nvmrc'
+      - name: Install dependencies
+        run: npm ci
+      - name: build
+        run: npm run build
+      - name: Setup Copywrite tool
+        uses: hashicorp/setup-copywrite@v1.1.2
+      - name: Add headers using Copywrite tool
+        run: copywrite headers
+      - name: Find mutations
+        id: self_mutation
+        run: |-
+          git add .
+          git diff --staged --patch --exit-code > .repo.patch || echo "self_mutation_happened=true" >> $GITHUB_OUTPUT
+      - name: Upload patch
+        if: steps.self_mutation.outputs.self_mutation_happened
+        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.1
+        with:
+          name: .repo.patch
+          path: .repo.patch
+          overwrite: true
+      - name: Fail build on mutation
+        if: steps.self_mutation.outputs.self_mutation_happened
+        run: |-
+          echo "::error::Files were changed during build (see build log). If this was triggered from a fork, you will need to update your branch."
+          cat .repo.patch
+          exit 1
+  self-mutation:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    if: always() && needs.build.outputs.self_mutation_happened && !(github.event.pull_request.head.repo.full_name != github.repository)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - name: Download patch
+        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.2
+        with:
+          name: .repo.patch
+          path: ${{ runner.temp }}
+      - name: Apply patch
+        run: '[ -s ${{ runner.temp }}/.repo.patch ] && git apply ${{ runner.temp }}/.repo.patch || echo "Empty patch. Skipping."'
+      - name: Set git identity
+        run: |-
+          git config user.name "tf-editor-exp-ci-bot"
+          git config user.email "svc-github-team-tf-editor-experience@hashicorp.com"
+      - name: Push changes
+        env:
+          PULL_REQUEST_REF: ${{ github.event.pull_request.head.ref }}
+        run: |-
+          git add .
+          git commit -s -m "chore: self mutation"
+          git push origin HEAD:$PULL_REQUEST_REF
+
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+      with:
+        node-version-file: '.nvmrc'
+    - name: Install modules
+      run: npm ci
+    - name: Run vscode-tmgrammar-test
+      run: npm test

--- a/.github/workflows/pulls.yml
+++ b/.github/workflows/pulls.yml
@@ -53,6 +53,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
+          token: ${{ secrets.BOT_PUSH_GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Download patch

--- a/.github/workflows/pulls.yml
+++ b/.github/workflows/pulls.yml
@@ -17,6 +17,10 @@ jobs:
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version-file: '.nvmrc'
+      - name: Set up Go
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version-file: "go.mod"
       - name: Install dependencies
         run: npm ci
       - name: build

--- a/.github/workflows/pulls.yml
+++ b/.github/workflows/pulls.yml
@@ -21,10 +21,6 @@ jobs:
         run: npm ci
       - name: build
         run: npm run build
-      - name: Setup Copywrite tool
-        uses: hashicorp/setup-copywrite@v1.1.2
-      - name: Add headers using Copywrite tool
-        run: copywrite headers
       - name: Find mutations
         id: self_mutation
         run: |-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - "main"
-  pull_request:
-    branches:
-      - "main"
 
 jobs:
   copywrite:


### PR DESCRIPTION
This PR adds a new workflow to run on pull requests only while adjusting the existing test workflow to only run on commits on main from now on.

The following will happen on PRs now:
* `npm run build` will be run as part of a new build job
* `copywrite headers` will be run as part of the build job as well
* If there are any changes (e.g. to file headers) or to the generated syntax json files the diff will be committed as a new commit and the workflow is aborted
* If there are no changes (e.g. when running on the self-update commit after it has been made) the test job will run and decide the fate of whether the workflow fails or succeeds

This pattern is something we used over in CDKTF repositories a lot. It stems from the projen.io configuration management tool.

This change allows us to forget to run build and still get correct test results. Currently, if you forget to run build locally, the tests might still pass as they run against the now stale generated json grammar files.

### Todos

- [x] Need to set `token` on the checkout action in the job that does the patch commit. Without this Github actions won't re-run on the self-update commit.
- [x] Add bot user to CLA bot exceptions (request here: https://github.com/hashicorp/releng-support/issues/248)