### PR TITLE
Add support for namespaced functions to HCL grammar

### DIFF
--- a/src/_main.yml
+++ b/src/_main.yml
@@ -402,13 +402,15 @@ repository:
       "0":
         name: keyword.operator.splat.hcl
   functions:
-    begin: (\w+)(\()
+    begin: ([:\-\w]+)(\()
     name: meta.function-call.hcl
     comment: Built-in function calls
     beginCaptures:
       "1":
         patterns:
-          - match: \b(?!null|false|true)[[:alpha:]][[:alnum:]_-]*\b
+          - match: \b[[:alpha:]][\w_-]*::([[:alpha:]][\w_-]*::)?[[:alpha:]][\w_-]*\b
+            name: support.function.namespaced.hcl
+          - match: \b[[:alpha:]][\w_-]*\b
             name: support.function.builtin.hcl
       "2":
         name: punctuation.section.parens.begin.hcl

--- a/syntaxes/hcl.tmGrammar.json
+++ b/syntaxes/hcl.tmGrammar.json
@@ -283,14 +283,18 @@
     },
     "functions": {
       "name": "meta.function-call.hcl",
-      "begin": "(\\w+)(\\()",
+      "begin": "([:\\-\\w]+)(\\()",
       "end": "\\)",
       "comment": "Built-in function calls",
       "beginCaptures": {
         "1": {
           "patterns": [
             {
-              "match": "\\b(?!null|false|true)[[:alpha:]][[:alnum:]_-]*\\b",
+              "match": "\\b[[:alpha:]][\\w_-]*::([[:alpha:]][\\w_-]*::)?[[:alpha:]][\\w_-]*\\b",
+              "name": "support.function.namespaced.hcl"
+            },
+            {
+              "match": "\\b[[:alpha:]][\\w_-]*\\b",
               "name": "support.function.builtin.hcl"
             }
           ]

--- a/tests/snapshot/hcl/expressions_functions.hcl
+++ b/tests/snapshot/hcl/expressions_functions.hcl
@@ -35,3 +35,9 @@ upper("hello")
 # known
 
 foo("bar")
+
+prefix::namespace::func("bar")
+prefix::namespace::func()
+
+namespace::short("bar")
+namespace::short_name()

--- a/tests/snapshot/hcl/expressions_functions.hcl.snap
+++ b/tests/snapshot/hcl/expressions_functions.hcl.snap
@@ -357,3 +357,26 @@
 #        ^ source.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
 #         ^ source.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
 >
+>prefix::namespace::func("bar")
+#^^^^^^^^^^^^^^^^^^^^^^^ source.hcl meta.function-call.hcl support.function.namespaced.hcl
+#                       ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
+#                        ^ source.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                         ^^^ source.hcl meta.function-call.hcl string.quoted.double.hcl
+#                            ^ source.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                             ^ source.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
+>prefix::namespace::func()
+#^^^^^^^^^^^^^^^^^^^^^^^ source.hcl meta.function-call.hcl support.function.namespaced.hcl
+#                       ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
+#                        ^ source.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
+>
+>namespace::short("bar")
+#^^^^^^^^^^^^^^^^ source.hcl meta.function-call.hcl support.function.namespaced.hcl
+#                ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
+#                 ^ source.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                  ^^^ source.hcl meta.function-call.hcl string.quoted.double.hcl
+#                     ^ source.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                      ^ source.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
+>namespace::short_name()
+#^^^^^^^^^^^^^^^^^^^^^ source.hcl meta.function-call.hcl support.function.namespaced.hcl
+#                     ^ source.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
+#                      ^ source.hcl meta.function-call.hcl punctuation.section.parens.end.hcl


### PR DESCRIPTION
This PR adds support for namespaced functions to the HCL grammar.

It is a pre-requirement for https://github.com/hashicorp/syntax/issues/35 and will allow us to release a new vscode-hcl version.

## UX Before
<img width="634" alt="CleanShot 2024-03-12 at 09 40 16@2x" src="https://github.com/hashicorp/syntax/assets/45985/15ecb64b-de41-4568-b7d4-c1e7fe0353ba">

## UX After
<img width="640" alt="CleanShot 2024-03-12 at 09 37 49@2x" src="https://github.com/hashicorp/syntax/assets/45985/6216cf18-8a4f-4e5a-8fc2-d6ad383509d1">
