### PR TITLE
Add optional `core` prefix to Terraform functions

### DIFF
--- a/src/terraform.yml
+++ b/src/terraform.yml
@@ -45,10 +45,10 @@ repository:
     beginCaptures:
       "1":
         patterns:
-          - match: \b(abs|abspath|alltrue|anytrue|base64decode|base64encode|base64gzip|base64sha256|base64sha512|basename|bcrypt|can|ceil|chomp|chunklist|cidrhost|cidrnetmask|cidrsubnet|cidrsubnets|coalesce|coalescelist|compact|concat|contains|csvdecode|dirname|distinct|element|endswith|file|filebase64|filebase64sha256|filebase64sha512|fileexists|filemd5|fileset|filesha1|filesha256|filesha512|flatten|floor|format|formatdate|formatlist|indent|index|join|jsondecode|jsonencode|keys|length|log|lookup|lower|matchkeys|max|md5|merge|min|nonsensitive|one|parseint|pathexpand|plantimestamp|pow|range|regex|regexall|replace|reverse|rsadecrypt|sensitive|setintersection|setproduct|setsubtract|setunion|sha1|sha256|sha512|signum|slice|sort|split|startswith|strcontains|strrev|substr|sum|templatefile|textdecodebase64|textencodebase64|timeadd|timecmp|timestamp|title|tobool|tolist|tomap|tonumber|toset|tostring|transpose|trim|trimprefix|trimspace|trimsuffix|try|upper|urlencode|uuid|uuidv5|values|yamldecode|yamlencode|zipmap)\b
+          - match: \b(core::)?(abs|abspath|alltrue|anytrue|base64decode|base64encode|base64gzip|base64sha256|base64sha512|basename|bcrypt|can|ceil|chomp|chunklist|cidrhost|cidrnetmask|cidrsubnet|cidrsubnets|coalesce|coalescelist|compact|concat|contains|csvdecode|dirname|distinct|element|endswith|file|filebase64|filebase64sha256|filebase64sha512|fileexists|filemd5|fileset|filesha1|filesha256|filesha512|flatten|floor|format|formatdate|formatlist|indent|index|join|jsondecode|jsonencode|keys|length|log|lookup|lower|matchkeys|max|md5|merge|min|nonsensitive|one|parseint|pathexpand|plantimestamp|pow|range|regex|regexall|replace|reverse|rsadecrypt|sensitive|setintersection|setproduct|setsubtract|setunion|sha1|sha256|sha512|signum|slice|sort|split|startswith|strcontains|strrev|substr|sum|templatefile|textdecodebase64|textencodebase64|timeadd|timecmp|timestamp|title|tobool|tolist|tomap|tonumber|toset|tostring|transpose|trim|trimprefix|trimspace|trimsuffix|try|upper|urlencode|uuid|uuidv5|values|yamldecode|yamlencode|zipmap)\b
             name: support.function.builtin.terraform
           - match: \bprovider::[[:alpha:]][\w_-]*::[[:alpha:]][\w_-]*\b
-            name: support.function.provider
+            name: support.function.provider.terraform
       "2":
         name: punctuation.section.parens.begin.hcl
     end: \)

--- a/syntaxes/terraform.tmGrammar.json
+++ b/syntaxes/terraform.tmGrammar.json
@@ -291,12 +291,12 @@
         "1": {
           "patterns": [
             {
-              "match": "\\b(abs|abspath|alltrue|anytrue|base64decode|base64encode|base64gzip|base64sha256|base64sha512|basename|bcrypt|can|ceil|chomp|chunklist|cidrhost|cidrnetmask|cidrsubnet|cidrsubnets|coalesce|coalescelist|compact|concat|contains|csvdecode|dirname|distinct|element|endswith|file|filebase64|filebase64sha256|filebase64sha512|fileexists|filemd5|fileset|filesha1|filesha256|filesha512|flatten|floor|format|formatdate|formatlist|indent|index|join|jsondecode|jsonencode|keys|length|log|lookup|lower|matchkeys|max|md5|merge|min|nonsensitive|one|parseint|pathexpand|plantimestamp|pow|range|regex|regexall|replace|reverse|rsadecrypt|sensitive|setintersection|setproduct|setsubtract|setunion|sha1|sha256|sha512|signum|slice|sort|split|startswith|strcontains|strrev|substr|sum|templatefile|textdecodebase64|textencodebase64|timeadd|timecmp|timestamp|title|tobool|tolist|tomap|tonumber|toset|tostring|transpose|trim|trimprefix|trimspace|trimsuffix|try|upper|urlencode|uuid|uuidv5|values|yamldecode|yamlencode|zipmap)\\b",
+              "match": "\\b(core::)?(abs|abspath|alltrue|anytrue|base64decode|base64encode|base64gzip|base64sha256|base64sha512|basename|bcrypt|can|ceil|chomp|chunklist|cidrhost|cidrnetmask|cidrsubnet|cidrsubnets|coalesce|coalescelist|compact|concat|contains|csvdecode|dirname|distinct|element|endswith|file|filebase64|filebase64sha256|filebase64sha512|fileexists|filemd5|fileset|filesha1|filesha256|filesha512|flatten|floor|format|formatdate|formatlist|indent|index|join|jsondecode|jsonencode|keys|length|log|lookup|lower|matchkeys|max|md5|merge|min|nonsensitive|one|parseint|pathexpand|plantimestamp|pow|range|regex|regexall|replace|reverse|rsadecrypt|sensitive|setintersection|setproduct|setsubtract|setunion|sha1|sha256|sha512|signum|slice|sort|split|startswith|strcontains|strrev|substr|sum|templatefile|textdecodebase64|textencodebase64|timeadd|timecmp|timestamp|title|tobool|tolist|tomap|tonumber|toset|tostring|transpose|trim|trimprefix|trimspace|trimsuffix|try|upper|urlencode|uuid|uuidv5|values|yamldecode|yamlencode|zipmap)\\b",
               "name": "support.function.builtin.terraform"
             },
             {
               "match": "\\bprovider::[[:alpha:]][\\w_-]*::[[:alpha:]][\\w_-]*\\b",
-              "name": "support.function.provider"
+              "name": "support.function.provider.terraform"
             }
           ]
         },

--- a/tests/snapshot/terraform/expressions_functions.tf
+++ b/tests/snapshot/terraform/expressions_functions.tf
@@ -40,3 +40,8 @@ foo("bar")
 
 provider::framework::example("hi")
 invalid::namespaced::function("bye")
+
+provider::aws::abs(4)
+core::abs(4)
+
+provider::local::direxists("/path")

--- a/tests/snapshot/terraform/expressions_functions.tf.snap
+++ b/tests/snapshot/terraform/expressions_functions.tf.snap
@@ -362,7 +362,7 @@
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl.terraform comment.line.number-sign.hcl
 >
 >provider::framework::example("hi")
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl.terraform meta.function-call.hcl support.function.provider
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl.terraform meta.function-call.hcl support.function.provider.terraform
 #                            ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.begin.hcl
 #                             ^ source.hcl.terraform meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
 #                              ^^ source.hcl.terraform meta.function-call.hcl string.quoted.double.hcl
@@ -376,3 +376,21 @@
 #                                  ^ source.hcl.terraform meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
 #                                   ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.end.hcl
 >
+>provider::aws::abs(4)
+#^^^^^^^^^^^^^^^^^^ source.hcl.terraform meta.function-call.hcl support.function.provider.terraform
+#                  ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.begin.hcl
+#                   ^ source.hcl.terraform meta.function-call.hcl constant.numeric.integer.hcl
+#                    ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.end.hcl
+>core::abs(4)
+#^^^^^^^^^ source.hcl.terraform meta.function-call.hcl support.function.builtin.terraform
+#         ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.begin.hcl
+#          ^ source.hcl.terraform meta.function-call.hcl constant.numeric.integer.hcl
+#           ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.end.hcl
+>
+>provider::local::direxists("/path")
+#^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl.terraform meta.function-call.hcl support.function.provider.terraform
+#                          ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.begin.hcl
+#                           ^ source.hcl.terraform meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                            ^^^^^ source.hcl.terraform meta.function-call.hcl string.quoted.double.hcl
+#                                 ^ source.hcl.terraform meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                                  ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.end.hcl


### PR DESCRIPTION
This PR adds two minor fixes to the Terraform grammar for provider-defined functions:
* Add the missing `terraform` suffix to the Textmate scope
* Add an optional `core::` prefix to the built-in functions

And a couple of test cases to ensure that we don't highlight built-in functions or keywords differently when they're part of a namespaced function.