### PR TITLE
Improve highlighting within objects/maps

### DIFF
--- a/src/_main.yml
+++ b/src/_main.yml
@@ -264,16 +264,13 @@ repository:
       - include: "#objects"
       - include: "#inline_for_expression"
       - include: "#inline_if_expression"
-      - match: \b((?!null|false|true)[[:alpha:]][[:alnum:]_-]*)\s*(\=\>?)\s*
+      - match: \b((?!null|false|true)[[:alpha:]][[:alnum:]_-]*)\s*(\=(?!=))\s*
         comment: Literal, named object key
         captures:
           "1":
             name: meta.mapping.key.hcl variable.other.readwrite.hcl
           "2":
             name: keyword.operator.assignment.hcl
-            patterns:
-              - match: \=\>
-                name: storage.type.function.hcl
       - match: \b((").*("))\s*(\=)\s*
         comment: String object key
         captures:

--- a/src/_main.yml
+++ b/src/_main.yml
@@ -90,7 +90,7 @@ repository:
             match: '\"[^\"\r\n]*\"'
           - name: variable.other.enummember.hcl
             comment: Block label (Indentifier)
-            match: '[[:alpha:]][[:alnum:]_-]*'
+            match: "[[:alpha:]][[:alnum:]_-]*"
       "3":
         name: punctuation.section.block.begin.hcl
     end: \}

--- a/src/_main.yml
+++ b/src/_main.yml
@@ -271,7 +271,7 @@ repository:
             name: meta.mapping.key.hcl variable.other.readwrite.hcl
           "2":
             name: keyword.operator.assignment.hcl
-      - match: \b((").*("))\s*(\=)\s*
+      - match: ^\s*((").*("))\s*(\=)\s*
         comment: String object key
         captures:
           "1":

--- a/src/_main.yml
+++ b/src/_main.yml
@@ -229,7 +229,7 @@ repository:
       - match: \.\.\.
         name: keyword.operator.hcl
       - match: "\\:"
-        scope: keyword.operator.hcl
+        name: keyword.operator.hcl
   brackets:
     begin: \[
     beginCaptures:

--- a/syntaxes/hcl.tmGrammar.json
+++ b/syntaxes/hcl.tmGrammar.json
@@ -553,7 +553,7 @@
           }
         },
         {
-          "match": "\\b((\").*(\"))\\s*(\\=)\\s*",
+          "match": "^\\s*((\").*(\"))\\s*(\\=)\\s*",
           "comment": "String object key",
           "captures": {
             "1": {

--- a/syntaxes/hcl.tmGrammar.json
+++ b/syntaxes/hcl.tmGrammar.json
@@ -675,6 +675,7 @@
           "match": "\\.\\.\\."
         },
         {
+          "name": "keyword.operator.hcl",
           "match": "\\:"
         }
       ]

--- a/syntaxes/hcl.tmGrammar.json
+++ b/syntaxes/hcl.tmGrammar.json
@@ -541,20 +541,14 @@
           "include": "#inline_if_expression"
         },
         {
-          "match": "\\b((?!null|false|true)[[:alpha:]][[:alnum:]_-]*)\\s*(\\=\\>?)\\s*",
+          "match": "\\b((?!null|false|true)[[:alpha:]][[:alnum:]_-]*)\\s*(\\=(?!=))\\s*",
           "comment": "Literal, named object key",
           "captures": {
             "1": {
               "name": "meta.mapping.key.hcl variable.other.readwrite.hcl"
             },
             "2": {
-              "name": "keyword.operator.assignment.hcl",
-              "patterns": [
-                {
-                  "match": "\\=\\>",
-                  "name": "storage.type.function.hcl"
-                }
-              ]
+              "name": "keyword.operator.assignment.hcl"
             }
           }
         },

--- a/syntaxes/terraform.tmGrammar.json
+++ b/syntaxes/terraform.tmGrammar.json
@@ -691,6 +691,7 @@
           "match": "\\.\\.\\."
         },
         {
+          "name": "keyword.operator.hcl",
           "match": "\\:"
         }
       ]

--- a/tests/snapshot/hcl/expressions_conditional.hcl.snap
+++ b/tests/snapshot/hcl/expressions_conditional.hcl.snap
@@ -13,7 +13,7 @@
 #                 ^ source.hcl keyword.operator.accessor.hcl
 #                  ^ source.hcl variable.other.member.hcl
 #                   ^ source.hcl
-#                    ^ source.hcl
+#                    ^ source.hcl keyword.operator.hcl
 #                     ^ source.hcl
 #                      ^ source.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
 #                       ^^^^^^^^^ source.hcl string.quoted.double.hcl
@@ -30,7 +30,7 @@
 #                       ^^ source.hcl meta.function-call.hcl constant.numeric.integer.hcl
 #                         ^ source.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
 #                          ^ source.hcl
-#                           ^ source.hcl
+#                           ^ source.hcl keyword.operator.hcl
 #                            ^ source.hcl
 #                             ^ source.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
 #                              ^^^^^ source.hcl string.quoted.double.hcl
@@ -44,7 +44,7 @@
 #             ^ source.hcl
 #              ^^ source.hcl constant.numeric.integer.hcl
 #                ^ source.hcl
-#                 ^ source.hcl
+#                 ^ source.hcl keyword.operator.hcl
 #                  ^ source.hcl
 #                   ^ source.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
 #                    ^^^^^ source.hcl string.quoted.double.hcl

--- a/tests/snapshot/hcl/issue79.hcl
+++ b/tests/snapshot/hcl/issue79.hcl
@@ -1,0 +1,8 @@
+block {
+    attr = var.test
+    attr2 = var.test == "foo" ? "true" : "false"
+    nested_obj = {
+        attr = var.test
+        attr2 = var.test == "foo" ? "true" : "false"
+    }
+}

--- a/tests/snapshot/hcl/issue79.hcl
+++ b/tests/snapshot/hcl/issue79.hcl
@@ -4,5 +4,7 @@ block {
     nested_obj = {
         attr = var.test
         attr2 = var.test == "foo" ? "true" : "false"
+        "attr2" = var.test == "foo" ? "true" : "false"
+        (attr2) = var.test == "foo" ? "true" : "false"
     }
 }

--- a/tests/snapshot/hcl/issue79.hcl.snap
+++ b/tests/snapshot/hcl/issue79.hcl.snap
@@ -33,7 +33,7 @@
 #                                 ^^^^ source.hcl meta.block.hcl string.quoted.double.hcl
 #                                     ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
 #                                      ^ source.hcl meta.block.hcl
-#                                       ^ source.hcl meta.block.hcl
+#                                       ^ source.hcl meta.block.hcl keyword.operator.hcl
 #                                        ^ source.hcl meta.block.hcl
 #                                         ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
 #                                          ^^^^^ source.hcl meta.block.hcl string.quoted.double.hcl
@@ -73,7 +73,7 @@
 #                                     ^^^^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl
 #                                         ^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
 #                                          ^ source.hcl meta.block.hcl meta.braces.hcl
-#                                           ^ source.hcl meta.block.hcl meta.braces.hcl
+#                                           ^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.hcl
 #                                            ^ source.hcl meta.block.hcl meta.braces.hcl
 #                                             ^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
 #                                              ^^^^^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl

--- a/tests/snapshot/hcl/issue79.hcl.snap
+++ b/tests/snapshot/hcl/issue79.hcl.snap
@@ -76,6 +76,57 @@
 #                                             ^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
 #                                              ^^^^^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl
 #                                                   ^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+>        "attr2" = var.test == "foo" ? "true" : "false"
+#^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl
+#        ^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#         ^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl string.quoted.double.hcl
+#              ^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#               ^ source.hcl meta.block.hcl meta.braces.hcl
+#                ^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.hcl
+#                 ^ source.hcl meta.block.hcl meta.braces.hcl
+#                  ^^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl
+#                           ^^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.hcl
+#                             ^ source.hcl meta.block.hcl meta.braces.hcl
+#                              ^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                               ^^^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl
+#                                  ^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                                   ^ source.hcl meta.block.hcl meta.braces.hcl
+#                                    ^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.hcl
+#                                     ^ source.hcl meta.block.hcl meta.braces.hcl
+#                                      ^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                                       ^^^^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl
+#                                           ^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                                            ^ source.hcl meta.block.hcl meta.braces.hcl
+#                                             ^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.hcl
+#                                              ^ source.hcl meta.block.hcl meta.braces.hcl
+#                                               ^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                                                ^^^^^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl
+#                                                     ^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+>        (attr2) = var.test == "foo" ? "true" : "false"
+#^^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl punctuation.section.parens.begin.hcl
+#         ^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl
+#              ^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl punctuation.section.parens.end.hcl
+#               ^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl
+#                ^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl keyword.operator.hcl
+#                 ^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl
+#                  ^^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl
+#                           ^^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.hcl
+#                             ^ source.hcl meta.block.hcl meta.braces.hcl
+#                              ^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                               ^^^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl
+#                                  ^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                                   ^ source.hcl meta.block.hcl meta.braces.hcl
+#                                    ^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.hcl
+#                                     ^ source.hcl meta.block.hcl meta.braces.hcl
+#                                      ^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                                       ^^^^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl
+#                                           ^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                                            ^ source.hcl meta.block.hcl meta.braces.hcl
+#                                             ^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.hcl
+#                                              ^ source.hcl meta.block.hcl meta.braces.hcl
+#                                               ^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                                                ^^^^^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl
+#                                                     ^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
 >    }
 #^^^^ source.hcl meta.block.hcl meta.braces.hcl
 #    ^ source.hcl meta.block.hcl meta.braces.hcl punctuation.section.braces.end.hcl

--- a/tests/snapshot/hcl/issue79.hcl.snap
+++ b/tests/snapshot/hcl/issue79.hcl.snap
@@ -58,11 +58,9 @@
 #             ^ source.hcl meta.block.hcl meta.braces.hcl
 #              ^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.assignment.hcl
 #               ^ source.hcl meta.block.hcl meta.braces.hcl
-#                ^^^^ source.hcl meta.block.hcl meta.braces.hcl
-#                    ^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
-#                        ^ source.hcl meta.block.hcl meta.braces.hcl
-#                         ^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.assignment.hcl
-#                          ^^ source.hcl meta.block.hcl meta.braces.hcl
+#                ^^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl
+#                         ^^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.hcl
+#                           ^ source.hcl meta.block.hcl meta.braces.hcl
 #                            ^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
 #                             ^^^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl
 #                                ^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl

--- a/tests/snapshot/hcl/issue79.hcl.snap
+++ b/tests/snapshot/hcl/issue79.hcl.snap
@@ -1,0 +1,85 @@
+>block {
+#^^^^^ source.hcl meta.block.hcl entity.name.type.hcl
+#     ^ source.hcl meta.block.hcl
+#      ^ source.hcl meta.block.hcl punctuation.section.block.begin.hcl
+>    attr = var.test
+#^^^^ source.hcl meta.block.hcl
+#    ^^^^ source.hcl meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#        ^ source.hcl meta.block.hcl variable.declaration.hcl
+#         ^ source.hcl meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#          ^ source.hcl meta.block.hcl variable.declaration.hcl
+#           ^^^ source.hcl meta.block.hcl
+#              ^ source.hcl meta.block.hcl keyword.operator.accessor.hcl
+#               ^^^^ source.hcl meta.block.hcl variable.other.member.hcl
+>    attr2 = var.test == "foo" ? "true" : "false"
+#^^^^ source.hcl meta.block.hcl
+#    ^^^^^ source.hcl meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#         ^ source.hcl meta.block.hcl variable.declaration.hcl
+#          ^ source.hcl meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#           ^ source.hcl meta.block.hcl variable.declaration.hcl
+#            ^^^ source.hcl meta.block.hcl
+#               ^ source.hcl meta.block.hcl keyword.operator.accessor.hcl
+#                ^^^^ source.hcl meta.block.hcl variable.other.member.hcl
+#                    ^ source.hcl meta.block.hcl
+#                     ^^ source.hcl meta.block.hcl keyword.operator.hcl
+#                       ^ source.hcl meta.block.hcl
+#                        ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                         ^^^ source.hcl meta.block.hcl string.quoted.double.hcl
+#                            ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                             ^ source.hcl meta.block.hcl
+#                              ^ source.hcl meta.block.hcl keyword.operator.hcl
+#                               ^ source.hcl meta.block.hcl
+#                                ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                                 ^^^^ source.hcl meta.block.hcl string.quoted.double.hcl
+#                                     ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                                      ^ source.hcl meta.block.hcl
+#                                       ^ source.hcl meta.block.hcl
+#                                        ^ source.hcl meta.block.hcl
+#                                         ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                                          ^^^^^ source.hcl meta.block.hcl string.quoted.double.hcl
+#                                               ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+>    nested_obj = {
+#^^^^ source.hcl meta.block.hcl
+#    ^^^^^^^^^^ source.hcl meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#              ^ source.hcl meta.block.hcl variable.declaration.hcl
+#               ^ source.hcl meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#                ^ source.hcl meta.block.hcl variable.declaration.hcl
+#                 ^ source.hcl meta.block.hcl meta.braces.hcl punctuation.section.braces.begin.hcl
+>        attr = var.test
+#^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl
+#        ^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
+#            ^ source.hcl meta.block.hcl meta.braces.hcl
+#             ^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.assignment.hcl
+#              ^ source.hcl meta.block.hcl meta.braces.hcl
+#               ^^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl
+>        attr2 = var.test == "foo" ? "true" : "false"
+#^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl
+#        ^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
+#             ^ source.hcl meta.block.hcl meta.braces.hcl
+#              ^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.assignment.hcl
+#               ^ source.hcl meta.block.hcl meta.braces.hcl
+#                ^^^^ source.hcl meta.block.hcl meta.braces.hcl
+#                    ^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
+#                        ^ source.hcl meta.block.hcl meta.braces.hcl
+#                         ^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.assignment.hcl
+#                          ^^ source.hcl meta.block.hcl meta.braces.hcl
+#                            ^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                             ^^^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl
+#                                ^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                                 ^ source.hcl meta.block.hcl meta.braces.hcl
+#                                  ^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.hcl
+#                                   ^ source.hcl meta.block.hcl meta.braces.hcl
+#                                    ^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                                     ^^^^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl
+#                                         ^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                                          ^ source.hcl meta.block.hcl meta.braces.hcl
+#                                           ^ source.hcl meta.block.hcl meta.braces.hcl
+#                                            ^ source.hcl meta.block.hcl meta.braces.hcl
+#                                             ^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                                              ^^^^^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl
+#                                                   ^ source.hcl meta.block.hcl meta.braces.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+>    }
+#^^^^ source.hcl meta.block.hcl meta.braces.hcl
+#    ^ source.hcl meta.block.hcl meta.braces.hcl punctuation.section.braces.end.hcl
+>}
+#^ source.hcl meta.block.hcl punctuation.section.block.end.hcl

--- a/tests/snapshot/hcl/issue941.hcl.snap
+++ b/tests/snapshot/hcl/issue941.hcl.snap
@@ -41,7 +41,7 @@
 #                                     ^^^^^^^ source.hcl comment.line.number-sign.hcl
 >  :                                 #Comment
 #^^ source.hcl
-#  ^ source.hcl
+#  ^ source.hcl keyword.operator.hcl
 #   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl
 #                                    ^ source.hcl comment.line.number-sign.hcl punctuation.definition.comment.hcl
 #                                     ^^^^^^^ source.hcl comment.line.number-sign.hcl
@@ -73,7 +73,7 @@
 #                                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl comment.line.number-sign.hcl
 >    :                                                              #
 #^^^^ source.hcl
-#    ^ source.hcl
+#    ^ source.hcl keyword.operator.hcl
 #     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl
 #                                                                   ^ source.hcl comment.line.number-sign.hcl punctuation.definition.comment.hcl
 >    lookup(local.instance_size_map, local.cloud, null)             #If instance size is not provided and var.insane_mode is false, lookup in this table.

--- a/tests/snapshot/terraform/expressions_conditional.tf.snap
+++ b/tests/snapshot/terraform/expressions_conditional.tf.snap
@@ -14,7 +14,7 @@
 #                 ^ source.hcl.terraform keyword.operator.accessor.hcl
 #                  ^ source.hcl.terraform variable.other.member.hcl
 #                   ^ source.hcl.terraform
-#                    ^ source.hcl.terraform
+#                    ^ source.hcl.terraform keyword.operator.hcl
 #                     ^ source.hcl.terraform
 #                      ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.begin.hcl
 #                       ^^^^^^^^^ source.hcl.terraform string.quoted.double.hcl
@@ -31,7 +31,7 @@
 #                       ^^ source.hcl.terraform meta.function-call.hcl constant.numeric.integer.hcl
 #                         ^ source.hcl.terraform meta.function-call.hcl punctuation.section.parens.end.hcl
 #                          ^ source.hcl.terraform
-#                           ^ source.hcl.terraform
+#                           ^ source.hcl.terraform keyword.operator.hcl
 #                            ^ source.hcl.terraform
 #                             ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.begin.hcl
 #                              ^^^^^ source.hcl.terraform string.quoted.double.hcl
@@ -45,7 +45,7 @@
 #             ^ source.hcl.terraform
 #              ^^ source.hcl.terraform constant.numeric.integer.hcl
 #                ^ source.hcl.terraform
-#                 ^ source.hcl.terraform
+#                 ^ source.hcl.terraform keyword.operator.hcl
 #                  ^ source.hcl.terraform
 #                   ^ source.hcl.terraform string.quoted.double.hcl punctuation.definition.string.begin.hcl
 #                    ^^^^^ source.hcl.terraform string.quoted.double.hcl

--- a/tests/snapshot/terraform/issue941.tf.snap
+++ b/tests/snapshot/terraform/issue941.tf.snap
@@ -42,7 +42,7 @@
 #                                     ^^^^^^^ source.hcl.terraform comment.line.number-sign.hcl
 >  :                                 #Comment
 #^^ source.hcl.terraform
-#  ^ source.hcl.terraform
+#  ^ source.hcl.terraform keyword.operator.hcl
 #   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl.terraform
 #                                    ^ source.hcl.terraform comment.line.number-sign.hcl punctuation.definition.comment.hcl
 #                                     ^^^^^^^ source.hcl.terraform comment.line.number-sign.hcl
@@ -75,7 +75,7 @@
 #                                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl.terraform comment.line.number-sign.hcl
 >    :                                                              #
 #^^^^ source.hcl.terraform
-#    ^ source.hcl.terraform
+#    ^ source.hcl.terraform keyword.operator.hcl
 #     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl.terraform
 #                                                                   ^ source.hcl.terraform comment.line.number-sign.hcl punctuation.definition.comment.hcl
 >    lookup(local.instance_size_map, local.cloud, null)             #If instance size is not provided and var.insane_mode is false, lookup in this table.


### PR DESCRIPTION
This PR fixes a couple of issues related to highlighting in objects:
* `==` is now correctly detected within objects (as reported in #79)
* `:` is now correctly detected as operator (yaml typo)
* string-based object keys are correctly detected

## UX Before
<img width="620" alt="CleanShot 2024-03-20 at 12 08 12@2x" src="https://github.com/hashicorp/syntax/assets/45985/12b85e2b-78ba-449b-a3cf-78c4fe809554">

## UX After
<img width="620" alt="CleanShot 2024-03-20 at 12 06 56@2x" src="https://github.com/hashicorp/syntax/assets/45985/5ace05c4-28f8-417f-9f4b-01f50f471360">

