### PR TITLE
Fix mis-highlight for `=>`

### DIFF
--- a/src/_main.yml
+++ b/src/_main.yml
@@ -230,6 +230,8 @@ repository:
         name: keyword.operator.hcl
       - match: "\\:"
         name: keyword.operator.hcl
+      - match: \=\>
+        name: keyword.operator.hcl
   brackets:
     begin: \[
     beginCaptures:

--- a/syntaxes/hcl.tmGrammar.json
+++ b/syntaxes/hcl.tmGrammar.json
@@ -671,6 +671,10 @@
         {
           "name": "keyword.operator.hcl",
           "match": "\\:"
+        },
+        {
+          "name": "keyword.operator.hcl",
+          "match": "\\=\\>"
         }
       ]
     },

--- a/syntaxes/terraform.tmGrammar.json
+++ b/syntaxes/terraform.tmGrammar.json
@@ -693,6 +693,10 @@
         {
           "name": "keyword.operator.hcl",
           "match": "\\:"
+        },
+        {
+          "name": "keyword.operator.hcl",
+          "match": "\\=\\>"
         }
       ]
     },

--- a/tests/snapshot/hcl/issue114.hcl
+++ b/tests/snapshot/hcl/issue114.hcl
@@ -1,0 +1,7 @@
+byte_match_statement_rules = local.enabled && var.byte_match_statement_rules != null ? {
+  for rule in flatten(var.byte_match_statement_rules) :
+    format("%s-%s",
+      lookup(rule, "name", null) != null ? rule.name : format("%s-byte-match-%d", module.this.id, rule.priority),
+      rule.action,
+    ) => rule
+  } : {}

--- a/tests/snapshot/hcl/issue114.hcl.snap
+++ b/tests/snapshot/hcl/issue114.hcl.snap
@@ -83,8 +83,8 @@
 >    ) => rule
 #^^^^ source.hcl meta.block.hcl meta.function-call.hcl
 #    ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
-#     ^^ source.hcl meta.block.hcl
-#       ^ source.hcl meta.block.hcl keyword.operator.hcl
+#     ^ source.hcl meta.block.hcl
+#      ^^ source.hcl meta.block.hcl keyword.operator.hcl
 #        ^^^^^^ source.hcl meta.block.hcl
 >  } : {}
 #^^ source.hcl meta.block.hcl

--- a/tests/snapshot/hcl/issue114.hcl.snap
+++ b/tests/snapshot/hcl/issue114.hcl.snap
@@ -1,0 +1,96 @@
+>byte_match_statement_rules = local.enabled && var.byte_match_statement_rules != null ? {
+#^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#                          ^ source.hcl variable.declaration.hcl
+#                           ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#                            ^ source.hcl variable.declaration.hcl
+#                             ^^^^^ source.hcl meta.block.hcl entity.name.type.hcl
+#                                  ^ source.hcl meta.block.hcl
+#                                   ^^^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                                          ^^^^ source.hcl meta.block.hcl
+#                                              ^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                                                 ^ source.hcl meta.block.hcl
+#                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                                                                            ^^^^ source.hcl meta.block.hcl
+#                                                                                ^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                                                                                    ^^^ source.hcl meta.block.hcl
+#                                                                                       ^ source.hcl meta.block.hcl punctuation.section.block.begin.hcl
+>  for rule in flatten(var.byte_match_statement_rules) :
+#^^^^^^^^^^^^^^ source.hcl meta.block.hcl
+#              ^^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl support.function.builtin.hcl
+#                     ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
+#                      ^^^ source.hcl meta.block.hcl meta.function-call.hcl
+#                         ^ source.hcl meta.block.hcl meta.function-call.hcl keyword.operator.accessor.hcl
+#                          ^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl variable.other.member.hcl
+#                                                    ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
+#                                                     ^ source.hcl meta.block.hcl
+#                                                      ^ source.hcl meta.block.hcl keyword.operator.hcl
+>    format("%s-%s",
+#^^^^ source.hcl meta.block.hcl
+#    ^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl support.function.builtin.hcl
+#          ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
+#           ^ source.hcl meta.block.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#            ^^^^^ source.hcl meta.block.hcl meta.function-call.hcl string.quoted.double.hcl
+#                 ^ source.hcl meta.block.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                  ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.separator.hcl
+>      lookup(rule, "name", null) != null ? rule.name : format("%s-byte-match-%d", module.this.id, rule.priority),
+#^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl
+#      ^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl support.function.builtin.hcl
+#            ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
+#             ^^^^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl
+#                 ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl punctuation.separator.hcl
+#                  ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl
+#                   ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                    ^^^^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl string.quoted.double.hcl
+#                        ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                         ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl punctuation.separator.hcl
+#                          ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl
+#                           ^^^^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl constant.language.hcl
+#                               ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
+#                                ^ source.hcl meta.block.hcl meta.function-call.hcl
+#                                 ^^ source.hcl meta.block.hcl meta.function-call.hcl keyword.operator.hcl
+#                                   ^ source.hcl meta.block.hcl meta.function-call.hcl
+#                                    ^^^^ source.hcl meta.block.hcl meta.function-call.hcl constant.language.hcl
+#                                        ^ source.hcl meta.block.hcl meta.function-call.hcl
+#                                         ^ source.hcl meta.block.hcl meta.function-call.hcl keyword.operator.hcl
+#                                          ^^^^^ source.hcl meta.block.hcl meta.function-call.hcl
+#                                               ^ source.hcl meta.block.hcl meta.function-call.hcl keyword.operator.accessor.hcl
+#                                                ^^^^ source.hcl meta.block.hcl meta.function-call.hcl variable.other.member.hcl
+#                                                    ^ source.hcl meta.block.hcl meta.function-call.hcl
+#                                                     ^ source.hcl meta.block.hcl meta.function-call.hcl keyword.operator.hcl
+#                                                      ^ source.hcl meta.block.hcl meta.function-call.hcl
+#                                                       ^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl support.function.builtin.hcl
+#                                                             ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
+#                                                              ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                                                               ^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl string.quoted.double.hcl
+#                                                                               ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                                                                                ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl punctuation.separator.hcl
+#                                                                                 ^^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl
+#                                                                                        ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl keyword.operator.accessor.hcl
+#                                                                                         ^^^^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl variable.other.member.hcl
+#                                                                                             ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl keyword.operator.accessor.hcl
+#                                                                                              ^^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl variable.other.member.hcl
+#                                                                                                ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl punctuation.separator.hcl
+#                                                                                                 ^^^^^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl
+#                                                                                                      ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl keyword.operator.accessor.hcl
+#                                                                                                       ^^^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl variable.other.member.hcl
+#                                                                                                               ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
+#                                                                                                                ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.separator.hcl
+>      rule.action,
+#^^^^^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl
+#          ^ source.hcl meta.block.hcl meta.function-call.hcl keyword.operator.accessor.hcl
+#           ^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl variable.other.member.hcl
+#                 ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.separator.hcl
+>    ) => rule
+#^^^^ source.hcl meta.block.hcl meta.function-call.hcl
+#    ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
+#     ^^ source.hcl meta.block.hcl
+#       ^ source.hcl meta.block.hcl keyword.operator.hcl
+#        ^^^^^^ source.hcl meta.block.hcl
+>  } : {}
+#^^ source.hcl meta.block.hcl
+#  ^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
+#   ^ source.hcl
+#    ^ source.hcl keyword.operator.hcl
+#     ^ source.hcl
+#      ^ source.hcl meta.braces.hcl punctuation.section.braces.begin.hcl
+#       ^ source.hcl meta.braces.hcl punctuation.section.braces.end.hcl


### PR DESCRIPTION
Closes #114 

## UX Before
<img width="461" alt="CleanShot 2024-03-25 at 12 37 47@2x" src="https://github.com/hashicorp/syntax/assets/45985/607e64fb-1995-451b-8ef8-8c96575798a8">

## UX After
<img width="461" alt="CleanShot 2024-03-25 at 12 39 03@2x" src="https://github.com/hashicorp/syntax/assets/45985/bb6810d4-f060-4434-95a1-e9bc9f8370d0">
