### PR TITLE
Fix mis-highlight for conditionals detected as a block

### DIFF
--- a/src/_main.yml
+++ b/src/_main.yml
@@ -76,7 +76,7 @@ repository:
   block:
     name: meta.block.hcl
     comment: This will match HCL blocks like `thing1 "one" "two" {` or `thing2 {`
-    begin: ([\w][\-\w]*)([^{\r\n]*)(\{)
+    begin: ([\w][\-\w]*)([^?{\r\n]*)(\{)
     beginCaptures:
       "1":
         patterns:

--- a/syntaxes/hcl.tmGrammar.json
+++ b/syntaxes/hcl.tmGrammar.json
@@ -82,7 +82,7 @@
     },
     "block": {
       "name": "meta.block.hcl",
-      "begin": "([\\w][\\-\\w]*)([^{\\r\\n]*)(\\{)",
+      "begin": "([\\w][\\-\\w]*)([^?{\\r\\n]*)(\\{)",
       "end": "\\}",
       "comment": "This will match HCL blocks like `thing1 \"one\" \"two\" {` or `thing2 {`",
       "beginCaptures": {

--- a/tests/snapshot/hcl/block_labels.hcl
+++ b/tests/snapshot/hcl/block_labels.hcl
@@ -45,3 +45,5 @@ blockempty-newline "" {
 block-single-char-indentifier a {}
 block-single-char-indentifier-newline a {
 }
+
+byte_match_statement_rules = local.enabled && var.byte_match_statement_rules != null ? {

--- a/tests/snapshot/hcl/block_labels.hcl.snap
+++ b/tests/snapshot/hcl/block_labels.hcl.snap
@@ -242,3 +242,24 @@
 >}
 #^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
 >
+>byte_match_statement_rules = local.enabled && var.byte_match_statement_rules != null ? {
+#^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#                          ^ source.hcl variable.declaration.hcl
+#                           ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#                            ^ source.hcl variable.declaration.hcl
+#                             ^^^^^ source.hcl
+#                                  ^ source.hcl keyword.operator.accessor.hcl
+#                                   ^^^^^^^ source.hcl variable.other.member.hcl
+#                                          ^ source.hcl
+#                                           ^^ source.hcl keyword.operator.logical.hcl
+#                                             ^^^^ source.hcl
+#                                                 ^ source.hcl keyword.operator.accessor.hcl
+#                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl variable.other.member.hcl
+#                                                                            ^ source.hcl
+#                                                                             ^^ source.hcl keyword.operator.hcl
+#                                                                               ^ source.hcl
+#                                                                                ^^^^ source.hcl constant.language.hcl
+#                                                                                    ^ source.hcl
+#                                                                                     ^ source.hcl keyword.operator.hcl
+#                                                                                      ^ source.hcl
+#                                                                                       ^ source.hcl meta.braces.hcl punctuation.section.braces.begin.hcl

--- a/tests/snapshot/hcl/issue114.hcl.snap
+++ b/tests/snapshot/hcl/issue114.hcl.snap
@@ -3,92 +3,103 @@
 #                          ^ source.hcl variable.declaration.hcl
 #                           ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
 #                            ^ source.hcl variable.declaration.hcl
-#                             ^^^^^ source.hcl meta.block.hcl entity.name.type.hcl
-#                                  ^ source.hcl meta.block.hcl
-#                                   ^^^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
-#                                          ^^^^ source.hcl meta.block.hcl
-#                                              ^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
-#                                                 ^ source.hcl meta.block.hcl
-#                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
-#                                                                            ^^^^ source.hcl meta.block.hcl
-#                                                                                ^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
-#                                                                                    ^^^ source.hcl meta.block.hcl
-#                                                                                       ^ source.hcl meta.block.hcl punctuation.section.block.begin.hcl
+#                             ^^^^^ source.hcl
+#                                  ^ source.hcl keyword.operator.accessor.hcl
+#                                   ^^^^^^^ source.hcl variable.other.member.hcl
+#                                          ^ source.hcl
+#                                           ^^ source.hcl keyword.operator.logical.hcl
+#                                             ^^^^ source.hcl
+#                                                 ^ source.hcl keyword.operator.accessor.hcl
+#                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl variable.other.member.hcl
+#                                                                            ^ source.hcl
+#                                                                             ^^ source.hcl keyword.operator.hcl
+#                                                                               ^ source.hcl
+#                                                                                ^^^^ source.hcl constant.language.hcl
+#                                                                                    ^ source.hcl
+#                                                                                     ^ source.hcl keyword.operator.hcl
+#                                                                                      ^ source.hcl
+#                                                                                       ^ source.hcl meta.braces.hcl punctuation.section.braces.begin.hcl
 >  for rule in flatten(var.byte_match_statement_rules) :
-#^^^^^^^^^^^^^^ source.hcl meta.block.hcl
-#              ^^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl support.function.builtin.hcl
-#                     ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
-#                      ^^^ source.hcl meta.block.hcl meta.function-call.hcl
-#                         ^ source.hcl meta.block.hcl meta.function-call.hcl keyword.operator.accessor.hcl
-#                          ^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl variable.other.member.hcl
-#                                                    ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
-#                                                     ^ source.hcl meta.block.hcl
-#                                                      ^ source.hcl meta.block.hcl keyword.operator.hcl
+#^^ source.hcl meta.braces.hcl
+#  ^^^ source.hcl meta.braces.hcl keyword.control.hcl
+#     ^ source.hcl meta.braces.hcl
+#      ^^^^ source.hcl meta.braces.hcl variable.other.readwrite.hcl
+#          ^ source.hcl meta.braces.hcl
+#           ^^ source.hcl meta.braces.hcl keyword.operator.word.hcl
+#             ^ source.hcl meta.braces.hcl
+#              ^^^^^^^ source.hcl meta.braces.hcl meta.function-call.hcl support.function.builtin.hcl
+#                     ^ source.hcl meta.braces.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
+#                      ^^^ source.hcl meta.braces.hcl meta.function-call.hcl
+#                         ^ source.hcl meta.braces.hcl meta.function-call.hcl keyword.operator.accessor.hcl
+#                          ^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl meta.braces.hcl meta.function-call.hcl variable.other.member.hcl
+#                                                    ^ source.hcl meta.braces.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
+#                                                     ^ source.hcl meta.braces.hcl
+#                                                      ^ source.hcl meta.braces.hcl keyword.operator.hcl
 >    format("%s-%s",
-#^^^^ source.hcl meta.block.hcl
-#    ^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl support.function.builtin.hcl
-#          ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
-#           ^ source.hcl meta.block.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
-#            ^^^^^ source.hcl meta.block.hcl meta.function-call.hcl string.quoted.double.hcl
-#                 ^ source.hcl meta.block.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
-#                  ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.separator.hcl
+#^^^^ source.hcl meta.braces.hcl
+#    ^^^^^^ source.hcl meta.braces.hcl meta.function-call.hcl support.function.builtin.hcl
+#          ^ source.hcl meta.braces.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
+#           ^ source.hcl meta.braces.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#            ^^^^^ source.hcl meta.braces.hcl meta.function-call.hcl string.quoted.double.hcl
+#                 ^ source.hcl meta.braces.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                  ^ source.hcl meta.braces.hcl meta.function-call.hcl punctuation.separator.hcl
 >      lookup(rule, "name", null) != null ? rule.name : format("%s-byte-match-%d", module.this.id, rule.priority),
-#^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl
-#      ^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl support.function.builtin.hcl
-#            ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
-#             ^^^^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl
-#                 ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl punctuation.separator.hcl
-#                  ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl
-#                   ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
-#                    ^^^^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl string.quoted.double.hcl
-#                        ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
-#                         ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl punctuation.separator.hcl
-#                          ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl
-#                           ^^^^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl constant.language.hcl
-#                               ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
-#                                ^ source.hcl meta.block.hcl meta.function-call.hcl
-#                                 ^^ source.hcl meta.block.hcl meta.function-call.hcl keyword.operator.hcl
-#                                   ^ source.hcl meta.block.hcl meta.function-call.hcl
-#                                    ^^^^ source.hcl meta.block.hcl meta.function-call.hcl constant.language.hcl
-#                                        ^ source.hcl meta.block.hcl meta.function-call.hcl
-#                                         ^ source.hcl meta.block.hcl meta.function-call.hcl keyword.operator.hcl
-#                                          ^^^^^ source.hcl meta.block.hcl meta.function-call.hcl
-#                                               ^ source.hcl meta.block.hcl meta.function-call.hcl keyword.operator.accessor.hcl
-#                                                ^^^^ source.hcl meta.block.hcl meta.function-call.hcl variable.other.member.hcl
-#                                                    ^ source.hcl meta.block.hcl meta.function-call.hcl
-#                                                     ^ source.hcl meta.block.hcl meta.function-call.hcl keyword.operator.hcl
-#                                                      ^ source.hcl meta.block.hcl meta.function-call.hcl
-#                                                       ^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl support.function.builtin.hcl
-#                                                             ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
-#                                                              ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
-#                                                               ^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl string.quoted.double.hcl
-#                                                                               ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
-#                                                                                ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl punctuation.separator.hcl
-#                                                                                 ^^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl
-#                                                                                        ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl keyword.operator.accessor.hcl
-#                                                                                         ^^^^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl variable.other.member.hcl
-#                                                                                             ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl keyword.operator.accessor.hcl
-#                                                                                              ^^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl variable.other.member.hcl
-#                                                                                                ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl punctuation.separator.hcl
-#                                                                                                 ^^^^^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl
-#                                                                                                      ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl keyword.operator.accessor.hcl
-#                                                                                                       ^^^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl variable.other.member.hcl
-#                                                                                                               ^ source.hcl meta.block.hcl meta.function-call.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
-#                                                                                                                ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.separator.hcl
+#^^^^^^ source.hcl meta.braces.hcl meta.function-call.hcl
+#      ^^^^^^ source.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl support.function.builtin.hcl
+#            ^ source.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
+#             ^^^^ source.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl
+#                 ^ source.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl punctuation.separator.hcl
+#                  ^ source.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl
+#                   ^ source.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                    ^^^^ source.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl string.quoted.double.hcl
+#                        ^ source.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                         ^ source.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl punctuation.separator.hcl
+#                          ^ source.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl
+#                           ^^^^ source.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl constant.language.hcl
+#                               ^ source.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
+#                                ^ source.hcl meta.braces.hcl meta.function-call.hcl
+#                                 ^^ source.hcl meta.braces.hcl meta.function-call.hcl keyword.operator.hcl
+#                                   ^ source.hcl meta.braces.hcl meta.function-call.hcl
+#                                    ^^^^ source.hcl meta.braces.hcl meta.function-call.hcl constant.language.hcl
+#                                        ^ source.hcl meta.braces.hcl meta.function-call.hcl
+#                                         ^ source.hcl meta.braces.hcl meta.function-call.hcl keyword.operator.hcl
+#                                          ^^^^^ source.hcl meta.braces.hcl meta.function-call.hcl
+#                                               ^ source.hcl meta.braces.hcl meta.function-call.hcl keyword.operator.accessor.hcl
+#                                                ^^^^ source.hcl meta.braces.hcl meta.function-call.hcl variable.other.member.hcl
+#                                                    ^ source.hcl meta.braces.hcl meta.function-call.hcl
+#                                                     ^ source.hcl meta.braces.hcl meta.function-call.hcl keyword.operator.hcl
+#                                                      ^ source.hcl meta.braces.hcl meta.function-call.hcl
+#                                                       ^^^^^^ source.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl support.function.builtin.hcl
+#                                                             ^ source.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
+#                                                              ^ source.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                                                               ^^^^^^^^^^^^^^^^ source.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl string.quoted.double.hcl
+#                                                                               ^ source.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                                                                                ^ source.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl punctuation.separator.hcl
+#                                                                                 ^^^^^^^ source.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl
+#                                                                                        ^ source.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl keyword.operator.accessor.hcl
+#                                                                                         ^^^^ source.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl variable.other.member.hcl
+#                                                                                             ^ source.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl keyword.operator.accessor.hcl
+#                                                                                              ^^ source.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl variable.other.member.hcl
+#                                                                                                ^ source.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl punctuation.separator.hcl
+#                                                                                                 ^^^^^ source.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl
+#                                                                                                      ^ source.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl keyword.operator.accessor.hcl
+#                                                                                                       ^^^^^^^^ source.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl variable.other.member.hcl
+#                                                                                                               ^ source.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
+#                                                                                                                ^ source.hcl meta.braces.hcl meta.function-call.hcl punctuation.separator.hcl
 >      rule.action,
-#^^^^^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl
-#          ^ source.hcl meta.block.hcl meta.function-call.hcl keyword.operator.accessor.hcl
-#           ^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl variable.other.member.hcl
-#                 ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.separator.hcl
+#^^^^^^^^^^ source.hcl meta.braces.hcl meta.function-call.hcl
+#          ^ source.hcl meta.braces.hcl meta.function-call.hcl keyword.operator.accessor.hcl
+#           ^^^^^^ source.hcl meta.braces.hcl meta.function-call.hcl variable.other.member.hcl
+#                 ^ source.hcl meta.braces.hcl meta.function-call.hcl punctuation.separator.hcl
 >    ) => rule
-#^^^^ source.hcl meta.block.hcl meta.function-call.hcl
-#    ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
-#     ^ source.hcl meta.block.hcl
-#      ^^ source.hcl meta.block.hcl keyword.operator.hcl
-#        ^^^^^^ source.hcl meta.block.hcl
+#^^^^ source.hcl meta.braces.hcl meta.function-call.hcl
+#    ^ source.hcl meta.braces.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
+#     ^ source.hcl meta.braces.hcl
+#      ^^ source.hcl meta.braces.hcl keyword.operator.hcl
+#        ^^^^^^ source.hcl meta.braces.hcl
 >  } : {}
-#^^ source.hcl meta.block.hcl
-#  ^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
+#^^ source.hcl meta.braces.hcl
+#  ^ source.hcl meta.braces.hcl punctuation.section.braces.end.hcl
 #   ^ source.hcl
 #    ^ source.hcl keyword.operator.hcl
 #     ^ source.hcl


### PR DESCRIPTION
Looking at the screenshots from #115, I noticed that the `local` keyword was highlighted in a different way than in the current vscode-hcl grammar.

I traced this back to #94, which changed the recognition of blocks. I made this a little less permissive by disallowing `?` in block labels. This fixes the case where a ternary operator followed by an object is recognized as a block.

![CleanShot 2024-03-25 at 18 07 56@2x](https://github.com/hashicorp/syntax/assets/45985/f74aa99f-0b5d-4d0f-bbf8-d8cc0a36d40d)

## UX Before
<img width="912" alt="CleanShot 2024-03-25 at 18 28 16@2x" src="https://github.com/hashicorp/syntax/assets/45985/fe930654-a8b5-4d33-bc0e-7dd3ebec89a8">

## UX After
<img width="911" alt="CleanShot 2024-03-25 at 18 27 32@2x" src="https://github.com/hashicorp/syntax/assets/45985/c8370976-b889-4f5f-932d-7337e936fbad">
