### PR TITLE
Fix inline for-expression matching

### DIFF
--- a/src/_main.yml
+++ b/src/_main.yml
@@ -340,15 +340,15 @@ repository:
         name: storage.type.function.hcl
       - include: "#for_expression_body"
   inline_for_expression:
-    begin: (for)\b
-    beginCaptures:
+    match: (for)\b(.*)\n
+    captures:
       "1":
         name: keyword.control.hcl
-    end: \n
-    patterns:
-      - match: \=\>
-        name: storage.type.function.hcl
-      - include: "#for_expression_body"
+      "2":
+        patterns:
+          - match: \=\>
+            name: storage.type.function.hcl
+          - include: "#for_expression_body"
   inline_if_expression:
     begin: (if)\b
     beginCaptures:

--- a/syntaxes/hcl.tmGrammar.json
+++ b/syntaxes/hcl.tmGrammar.json
@@ -361,22 +361,23 @@
       ]
     },
     "inline_for_expression": {
-      "begin": "(for)\\b",
-      "end": "\\n",
-      "beginCaptures": {
+      "match": "(for)\\b(.*)\\n",
+      "captures": {
         "1": {
           "name": "keyword.control.hcl"
-        }
-      },
-      "patterns": [
-        {
-          "name": "storage.type.function.hcl",
-          "match": "\\=\\>"
         },
-        {
-          "include": "#for_expression_body"
+        "2": {
+          "patterns": [
+            {
+              "match": "\\=\\>",
+              "name": "storage.type.function.hcl"
+            },
+            {
+              "include": "#for_expression_body"
+            }
+          ]
         }
-      ]
+      }
     },
     "inline_if_expression": {
       "begin": "(if)\\b",

--- a/syntaxes/terraform.tmGrammar.json
+++ b/syntaxes/terraform.tmGrammar.json
@@ -362,22 +362,23 @@
       ]
     },
     "inline_for_expression": {
-      "begin": "(for)\\b",
-      "end": "\\n",
-      "beginCaptures": {
+      "match": "(for)\\b(.*)\\n",
+      "captures": {
         "1": {
           "name": "keyword.control.hcl"
-        }
-      },
-      "patterns": [
-        {
-          "name": "storage.type.function.hcl",
-          "match": "\\=\\>"
         },
-        {
-          "include": "#for_expression_body"
+        "2": {
+          "patterns": [
+            {
+              "match": "\\=\\>",
+              "name": "storage.type.function.hcl"
+            },
+            {
+              "include": "#for_expression_body"
+            }
+          ]
         }
-      ]
+      }
     },
     "inline_if_expression": {
       "begin": "(if)\\b",

--- a/tests/snapshot/hcl/issue113.hcl
+++ b/tests/snapshot/hcl/issue113.hcl
@@ -1,0 +1,25 @@
+dynamic "text_transformation" {
+  for_each = lookup(rule.value.statement, "text_transformation", null) != null ? [
+    for rule in lookup(rule.value.statement, "text_transformation") : {
+      priority = rule.priority
+      type     = rule.type
+  }] : []
+
+  content {
+    priority = text_transformation.value.priority
+    type     = text_transformation.value.type
+  }
+}
+
+locals {
+  byte_match_statement_rules = local.enabled && var.byte_match_statement_rules != null ? {
+    for rule in flatten(var.byte_match_statement_rules) :
+    format("%s-%s",
+      lookup(rule, "name", null) != null ? rule.name : format("%s-byte-match-%d", module.this.id, rule.priority),
+      rule.action,
+    ) => rule
+  } : {}
+}
+
+
+

--- a/tests/snapshot/hcl/issue113.hcl.snap
+++ b/tests/snapshot/hcl/issue113.hcl.snap
@@ -60,23 +60,23 @@
 #                                                                     ^ source.hcl meta.block.hcl
 #                                                                      ^ source.hcl meta.block.hcl meta.braces.hcl punctuation.section.braces.begin.hcl
 >      priority = rule.priority
-#^^^^^^ source.hcl meta.block.hcl meta.braces.hcl
-#      ^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
-#              ^ source.hcl meta.block.hcl meta.braces.hcl
-#               ^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.assignment.hcl
-#                ^ source.hcl meta.block.hcl meta.braces.hcl
-#                 ^^^^^^^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl
+#^^^^^^ source.hcl meta.block.hcl
+#      ^^^^^^^^ source.hcl meta.block.hcl variable.other.readwrite.hcl
+#              ^^^ source.hcl meta.block.hcl
+#                 ^^^^ source.hcl meta.block.hcl variable.other.readwrite.hcl
+#                     ^ source.hcl meta.block.hcl keyword.operator.accessor.hcl
+#                      ^^^^^^^^ source.hcl meta.block.hcl variable.other.member.hcl
 >      type     = rule.type
-#^^^^^^ source.hcl meta.block.hcl meta.braces.hcl
-#      ^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
-#          ^^^^^ source.hcl meta.block.hcl meta.braces.hcl
-#               ^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.assignment.hcl
-#                ^ source.hcl meta.block.hcl meta.braces.hcl
-#                 ^^^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl
+#^^^^^^ source.hcl meta.block.hcl
+#      ^^^^ source.hcl meta.block.hcl variable.other.readwrite.hcl
+#          ^^^^^^^ source.hcl meta.block.hcl
+#                 ^^^^ source.hcl meta.block.hcl variable.other.readwrite.hcl
+#                     ^ source.hcl meta.block.hcl keyword.operator.accessor.hcl
+#                      ^^^^ source.hcl meta.block.hcl variable.other.member.hcl
 >  }] : []
-#^^ source.hcl meta.block.hcl meta.braces.hcl
-#  ^ source.hcl meta.block.hcl meta.braces.hcl punctuation.section.braces.end.hcl
-#   ^^ source.hcl meta.block.hcl
+#^^^ source.hcl meta.block.hcl
+#   ^ source.hcl meta.block.hcl punctuation.section.brackets.end.hcl
+#    ^ source.hcl meta.block.hcl
 #     ^ source.hcl meta.block.hcl keyword.operator.hcl
 #      ^ source.hcl meta.block.hcl
 #       ^ source.hcl meta.block.hcl punctuation.section.brackets.begin.hcl
@@ -84,137 +84,151 @@
 >
 >  content {
 #^^ source.hcl meta.block.hcl
-#  ^^^^^^^ source.hcl meta.block.hcl variable.other.readwrite.hcl
-#         ^ source.hcl meta.block.hcl
-#          ^ source.hcl meta.block.hcl meta.braces.hcl punctuation.section.braces.begin.hcl
+#  ^^^^^^^ source.hcl meta.block.hcl meta.block.hcl entity.name.type.hcl
+#         ^ source.hcl meta.block.hcl meta.block.hcl
+#          ^ source.hcl meta.block.hcl meta.block.hcl punctuation.section.block.begin.hcl
 >    priority = text_transformation.value.priority
-#^^^^ source.hcl meta.block.hcl meta.braces.hcl
-#    ^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
-#            ^ source.hcl meta.block.hcl meta.braces.hcl
-#             ^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.assignment.hcl
-#              ^ source.hcl meta.block.hcl meta.braces.hcl
-#               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl
+#^^^^ source.hcl meta.block.hcl meta.block.hcl
+#    ^^^^^^^^ source.hcl meta.block.hcl meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#            ^ source.hcl meta.block.hcl meta.block.hcl variable.declaration.hcl
+#             ^ source.hcl meta.block.hcl meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#              ^ source.hcl meta.block.hcl meta.block.hcl variable.declaration.hcl
+#               ^^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl meta.block.hcl
+#                                  ^ source.hcl meta.block.hcl meta.block.hcl keyword.operator.accessor.hcl
+#                                   ^^^^^ source.hcl meta.block.hcl meta.block.hcl variable.other.member.hcl
+#                                        ^ source.hcl meta.block.hcl meta.block.hcl keyword.operator.accessor.hcl
+#                                         ^^^^^^^^ source.hcl meta.block.hcl meta.block.hcl variable.other.member.hcl
 >    type     = text_transformation.value.type
-#^^^^ source.hcl meta.block.hcl meta.braces.hcl
-#    ^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
-#        ^^^^^ source.hcl meta.block.hcl meta.braces.hcl
-#             ^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.assignment.hcl
-#              ^ source.hcl meta.block.hcl meta.braces.hcl
-#               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl
+#^^^^ source.hcl meta.block.hcl meta.block.hcl
+#    ^^^^ source.hcl meta.block.hcl meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#        ^^^^^ source.hcl meta.block.hcl meta.block.hcl variable.declaration.hcl
+#             ^ source.hcl meta.block.hcl meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#              ^ source.hcl meta.block.hcl meta.block.hcl variable.declaration.hcl
+#               ^^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl meta.block.hcl
+#                                  ^ source.hcl meta.block.hcl meta.block.hcl keyword.operator.accessor.hcl
+#                                   ^^^^^ source.hcl meta.block.hcl meta.block.hcl variable.other.member.hcl
+#                                        ^ source.hcl meta.block.hcl meta.block.hcl keyword.operator.accessor.hcl
+#                                         ^^^^ source.hcl meta.block.hcl meta.block.hcl variable.other.member.hcl
 >  }
-#^^ source.hcl meta.block.hcl meta.braces.hcl
-#  ^ source.hcl meta.block.hcl meta.braces.hcl punctuation.section.braces.end.hcl
+#^^ source.hcl meta.block.hcl meta.block.hcl
+#  ^ source.hcl meta.block.hcl meta.block.hcl punctuation.section.block.end.hcl
 >}
-#^^ source.hcl meta.block.hcl
+#^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
 >
 >locals {
-#^^^^^^ source.hcl meta.block.hcl variable.other.readwrite.hcl
+#^^^^^^ source.hcl meta.block.hcl entity.name.type.hcl
 #      ^ source.hcl meta.block.hcl
-#       ^ source.hcl meta.block.hcl meta.braces.hcl punctuation.section.braces.begin.hcl
+#       ^ source.hcl meta.block.hcl punctuation.section.block.begin.hcl
 >  byte_match_statement_rules = local.enabled && var.byte_match_statement_rules != null ? {
-#^^ source.hcl meta.block.hcl meta.braces.hcl
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
-#                            ^ source.hcl meta.block.hcl meta.braces.hcl
-#                             ^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.assignment.hcl
-#                              ^ source.hcl meta.block.hcl meta.braces.hcl
-#                               ^^^^^^^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl
-#                                             ^^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.logical.hcl
-#                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl
-#                                                                               ^^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.hcl
-#                                                                                 ^ source.hcl meta.block.hcl meta.braces.hcl
-#                                                                                  ^^^^ source.hcl meta.block.hcl meta.braces.hcl constant.language.hcl
-#                                                                                      ^ source.hcl meta.block.hcl meta.braces.hcl
-#                                                                                       ^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.hcl
-#                                                                                        ^ source.hcl meta.block.hcl meta.braces.hcl
-#                                                                                         ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl punctuation.section.braces.begin.hcl
+#^^ source.hcl meta.block.hcl
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#                            ^ source.hcl meta.block.hcl variable.declaration.hcl
+#                             ^ source.hcl meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#                              ^ source.hcl meta.block.hcl variable.declaration.hcl
+#                               ^^^^^ source.hcl meta.block.hcl
+#                                    ^ source.hcl meta.block.hcl keyword.operator.accessor.hcl
+#                                     ^^^^^^^ source.hcl meta.block.hcl variable.other.member.hcl
+#                                            ^ source.hcl meta.block.hcl
+#                                             ^^ source.hcl meta.block.hcl keyword.operator.logical.hcl
+#                                               ^^^^ source.hcl meta.block.hcl
+#                                                   ^ source.hcl meta.block.hcl keyword.operator.accessor.hcl
+#                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl variable.other.member.hcl
+#                                                                              ^ source.hcl meta.block.hcl
+#                                                                               ^^ source.hcl meta.block.hcl keyword.operator.hcl
+#                                                                                 ^ source.hcl meta.block.hcl
+#                                                                                  ^^^^ source.hcl meta.block.hcl constant.language.hcl
+#                                                                                      ^ source.hcl meta.block.hcl
+#                                                                                       ^ source.hcl meta.block.hcl keyword.operator.hcl
+#                                                                                        ^ source.hcl meta.block.hcl
+#                                                                                         ^ source.hcl meta.block.hcl meta.braces.hcl punctuation.section.braces.begin.hcl
 >    for rule in flatten(var.byte_match_statement_rules) :
-#^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl
-#    ^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl keyword.control.hcl
-#       ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl
-#        ^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl variable.other.readwrite.hcl
-#            ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl
-#             ^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl keyword.operator.word.hcl
-#               ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl
-#                ^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl support.function.builtin.hcl
-#                       ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
-#                        ^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl
-#                           ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl keyword.operator.accessor.hcl
-#                            ^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl variable.other.member.hcl
-#                                                      ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
-#                                                       ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl
-#                                                        ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl keyword.operator.hcl
+#^^^^ source.hcl meta.block.hcl meta.braces.hcl
+#    ^^^ source.hcl meta.block.hcl meta.braces.hcl keyword.control.hcl
+#       ^ source.hcl meta.block.hcl meta.braces.hcl
+#        ^^^^ source.hcl meta.block.hcl meta.braces.hcl variable.other.readwrite.hcl
+#            ^ source.hcl meta.block.hcl meta.braces.hcl
+#             ^^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.word.hcl
+#               ^ source.hcl meta.block.hcl meta.braces.hcl
+#                ^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl support.function.builtin.hcl
+#                       ^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
+#                        ^^^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl
+#                           ^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl keyword.operator.accessor.hcl
+#                            ^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl variable.other.member.hcl
+#                                                      ^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
+#                                                       ^ source.hcl meta.block.hcl meta.braces.hcl
+#                                                        ^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.hcl
 >    format("%s-%s",
-#^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl
-#    ^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl support.function.builtin.hcl
-#          ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
-#           ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
-#            ^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl string.quoted.double.hcl
-#                 ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
-#                  ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl punctuation.separator.hcl
+#^^^^ source.hcl meta.block.hcl meta.braces.hcl
+#    ^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl support.function.builtin.hcl
+#          ^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
+#           ^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#            ^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl string.quoted.double.hcl
+#                 ^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                  ^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl punctuation.separator.hcl
 >      lookup(rule, "name", null) != null ? rule.name : format("%s-byte-match-%d", module.this.id, rule.priority),
-#^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl
-#      ^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl support.function.builtin.hcl
-#            ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
-#             ^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl
-#                 ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl punctuation.separator.hcl
-#                  ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl
-#                   ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
-#                    ^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl string.quoted.double.hcl
-#                        ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
-#                         ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl punctuation.separator.hcl
-#                          ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl
-#                           ^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl constant.language.hcl
-#                               ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
-#                                ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl
-#                                 ^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl keyword.operator.hcl
-#                                   ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl
-#                                    ^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl constant.language.hcl
-#                                        ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl
-#                                         ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl keyword.operator.hcl
-#                                          ^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl
-#                                               ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl keyword.operator.accessor.hcl
-#                                                ^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl variable.other.member.hcl
-#                                                    ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl
-#                                                     ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl keyword.operator.hcl
-#                                                      ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl
-#                                                       ^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl support.function.builtin.hcl
-#                                                             ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
-#                                                              ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
-#                                                               ^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl string.quoted.double.hcl
-#                                                                               ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
-#                                                                                ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl punctuation.separator.hcl
-#                                                                                 ^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl
-#                                                                                        ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl keyword.operator.accessor.hcl
-#                                                                                         ^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl variable.other.member.hcl
-#                                                                                             ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl keyword.operator.accessor.hcl
-#                                                                                              ^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl variable.other.member.hcl
-#                                                                                                ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl punctuation.separator.hcl
-#                                                                                                 ^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl
-#                                                                                                      ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl keyword.operator.accessor.hcl
-#                                                                                                       ^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl variable.other.member.hcl
-#                                                                                                               ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
-#                                                                                                                ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl punctuation.separator.hcl
+#^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl
+#      ^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl support.function.builtin.hcl
+#            ^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
+#             ^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl
+#                 ^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl punctuation.separator.hcl
+#                  ^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl
+#                   ^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                    ^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl string.quoted.double.hcl
+#                        ^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                         ^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl punctuation.separator.hcl
+#                          ^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl
+#                           ^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl constant.language.hcl
+#                               ^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
+#                                ^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl
+#                                 ^^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl keyword.operator.hcl
+#                                   ^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl
+#                                    ^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl constant.language.hcl
+#                                        ^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl
+#                                         ^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl keyword.operator.hcl
+#                                          ^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl
+#                                               ^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl keyword.operator.accessor.hcl
+#                                                ^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl variable.other.member.hcl
+#                                                    ^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl
+#                                                     ^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl keyword.operator.hcl
+#                                                      ^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl
+#                                                       ^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl support.function.builtin.hcl
+#                                                             ^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
+#                                                              ^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                                                               ^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl string.quoted.double.hcl
+#                                                                               ^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                                                                                ^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl punctuation.separator.hcl
+#                                                                                 ^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl
+#                                                                                        ^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl keyword.operator.accessor.hcl
+#                                                                                         ^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl variable.other.member.hcl
+#                                                                                             ^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl keyword.operator.accessor.hcl
+#                                                                                              ^^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl variable.other.member.hcl
+#                                                                                                ^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl punctuation.separator.hcl
+#                                                                                                 ^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl
+#                                                                                                      ^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl keyword.operator.accessor.hcl
+#                                                                                                       ^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl variable.other.member.hcl
+#                                                                                                               ^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
+#                                                                                                                ^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl punctuation.separator.hcl
 >      rule.action,
-#^^^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl
-#          ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl keyword.operator.accessor.hcl
-#           ^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl variable.other.member.hcl
-#                 ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl punctuation.separator.hcl
+#^^^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl
+#          ^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl keyword.operator.accessor.hcl
+#           ^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl variable.other.member.hcl
+#                 ^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl punctuation.separator.hcl
 >    ) => rule
-#^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl
-#    ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
-#     ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl
-#      ^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl keyword.operator.hcl
-#        ^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl
->  } : {}
-#^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl
-#  ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl punctuation.section.braces.end.hcl
-#   ^ source.hcl meta.block.hcl meta.braces.hcl
-#    ^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.hcl
+#^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl
+#    ^ source.hcl meta.block.hcl meta.braces.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
 #     ^ source.hcl meta.block.hcl meta.braces.hcl
-#      ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl punctuation.section.braces.begin.hcl
-#       ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl punctuation.section.braces.end.hcl
+#      ^^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.hcl
+#        ^^^^^^ source.hcl meta.block.hcl meta.braces.hcl
+>  } : {}
+#^^ source.hcl meta.block.hcl meta.braces.hcl
+#  ^ source.hcl meta.block.hcl meta.braces.hcl punctuation.section.braces.end.hcl
+#   ^ source.hcl meta.block.hcl
+#    ^ source.hcl meta.block.hcl keyword.operator.hcl
+#     ^ source.hcl meta.block.hcl
+#      ^ source.hcl meta.block.hcl meta.braces.hcl punctuation.section.braces.begin.hcl
+#       ^ source.hcl meta.block.hcl meta.braces.hcl punctuation.section.braces.end.hcl
 >}
-#^ source.hcl meta.block.hcl meta.braces.hcl punctuation.section.braces.end.hcl
+#^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
 >
 >
 >

--- a/tests/snapshot/hcl/issue113.hcl.snap
+++ b/tests/snapshot/hcl/issue113.hcl.snap
@@ -1,0 +1,221 @@
+>dynamic "text_transformation" {
+#^^^^^^^ source.hcl meta.block.hcl entity.name.type.hcl
+#       ^ source.hcl meta.block.hcl
+#        ^^^^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                             ^ source.hcl meta.block.hcl
+#                              ^ source.hcl meta.block.hcl punctuation.section.block.begin.hcl
+>  for_each = lookup(rule.value.statement, "text_transformation", null) != null ? [
+#^^ source.hcl meta.block.hcl
+#  ^^^^^^^^ source.hcl meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#          ^ source.hcl meta.block.hcl variable.declaration.hcl
+#           ^ source.hcl meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#            ^ source.hcl meta.block.hcl variable.declaration.hcl
+#             ^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl support.function.builtin.hcl
+#                   ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
+#                    ^^^^ source.hcl meta.block.hcl meta.function-call.hcl
+#                        ^ source.hcl meta.block.hcl meta.function-call.hcl keyword.operator.accessor.hcl
+#                         ^^^^^ source.hcl meta.block.hcl meta.function-call.hcl variable.other.member.hcl
+#                              ^ source.hcl meta.block.hcl meta.function-call.hcl keyword.operator.accessor.hcl
+#                               ^^^^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl variable.other.member.hcl
+#                                        ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.separator.hcl
+#                                         ^ source.hcl meta.block.hcl meta.function-call.hcl
+#                                          ^ source.hcl meta.block.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                                           ^^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl string.quoted.double.hcl
+#                                                              ^ source.hcl meta.block.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                                                               ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.separator.hcl
+#                                                                ^ source.hcl meta.block.hcl meta.function-call.hcl
+#                                                                 ^^^^ source.hcl meta.block.hcl meta.function-call.hcl constant.language.hcl
+#                                                                     ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
+#                                                                      ^ source.hcl meta.block.hcl
+#                                                                       ^^ source.hcl meta.block.hcl keyword.operator.hcl
+#                                                                         ^ source.hcl meta.block.hcl
+#                                                                          ^^^^ source.hcl meta.block.hcl constant.language.hcl
+#                                                                              ^ source.hcl meta.block.hcl
+#                                                                               ^ source.hcl meta.block.hcl keyword.operator.hcl
+#                                                                                ^ source.hcl meta.block.hcl
+#                                                                                 ^ source.hcl meta.block.hcl punctuation.section.brackets.begin.hcl
+>    for rule in lookup(rule.value.statement, "text_transformation") : {
+#^^^^ source.hcl meta.block.hcl
+#    ^^^ source.hcl meta.block.hcl keyword.control.hcl
+#       ^ source.hcl meta.block.hcl
+#        ^^^^ source.hcl meta.block.hcl variable.other.readwrite.hcl
+#            ^ source.hcl meta.block.hcl
+#             ^^ source.hcl meta.block.hcl keyword.operator.word.hcl
+#               ^ source.hcl meta.block.hcl
+#                ^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl support.function.builtin.hcl
+#                      ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
+#                       ^^^^ source.hcl meta.block.hcl meta.function-call.hcl
+#                           ^ source.hcl meta.block.hcl meta.function-call.hcl keyword.operator.accessor.hcl
+#                            ^^^^^ source.hcl meta.block.hcl meta.function-call.hcl variable.other.member.hcl
+#                                 ^ source.hcl meta.block.hcl meta.function-call.hcl keyword.operator.accessor.hcl
+#                                  ^^^^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl variable.other.member.hcl
+#                                           ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.separator.hcl
+#                                            ^ source.hcl meta.block.hcl meta.function-call.hcl
+#                                             ^ source.hcl meta.block.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                                              ^^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl meta.function-call.hcl string.quoted.double.hcl
+#                                                                 ^ source.hcl meta.block.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                                                                  ^ source.hcl meta.block.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
+#                                                                   ^ source.hcl meta.block.hcl
+#                                                                    ^ source.hcl meta.block.hcl keyword.operator.hcl
+#                                                                     ^ source.hcl meta.block.hcl
+#                                                                      ^ source.hcl meta.block.hcl meta.braces.hcl punctuation.section.braces.begin.hcl
+>      priority = rule.priority
+#^^^^^^ source.hcl meta.block.hcl meta.braces.hcl
+#      ^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
+#              ^ source.hcl meta.block.hcl meta.braces.hcl
+#               ^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.assignment.hcl
+#                ^ source.hcl meta.block.hcl meta.braces.hcl
+#                 ^^^^^^^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl
+>      type     = rule.type
+#^^^^^^ source.hcl meta.block.hcl meta.braces.hcl
+#      ^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
+#          ^^^^^ source.hcl meta.block.hcl meta.braces.hcl
+#               ^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.assignment.hcl
+#                ^ source.hcl meta.block.hcl meta.braces.hcl
+#                 ^^^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl
+>  }] : []
+#^^ source.hcl meta.block.hcl meta.braces.hcl
+#  ^ source.hcl meta.block.hcl meta.braces.hcl punctuation.section.braces.end.hcl
+#   ^^ source.hcl meta.block.hcl
+#     ^ source.hcl meta.block.hcl keyword.operator.hcl
+#      ^ source.hcl meta.block.hcl
+#       ^ source.hcl meta.block.hcl punctuation.section.brackets.begin.hcl
+#        ^ source.hcl meta.block.hcl punctuation.section.brackets.end.hcl
+>
+>  content {
+#^^ source.hcl meta.block.hcl
+#  ^^^^^^^ source.hcl meta.block.hcl variable.other.readwrite.hcl
+#         ^ source.hcl meta.block.hcl
+#          ^ source.hcl meta.block.hcl meta.braces.hcl punctuation.section.braces.begin.hcl
+>    priority = text_transformation.value.priority
+#^^^^ source.hcl meta.block.hcl meta.braces.hcl
+#    ^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
+#            ^ source.hcl meta.block.hcl meta.braces.hcl
+#             ^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.assignment.hcl
+#              ^ source.hcl meta.block.hcl meta.braces.hcl
+#               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl
+>    type     = text_transformation.value.type
+#^^^^ source.hcl meta.block.hcl meta.braces.hcl
+#    ^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
+#        ^^^^^ source.hcl meta.block.hcl meta.braces.hcl
+#             ^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.assignment.hcl
+#              ^ source.hcl meta.block.hcl meta.braces.hcl
+#               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl
+>  }
+#^^ source.hcl meta.block.hcl meta.braces.hcl
+#  ^ source.hcl meta.block.hcl meta.braces.hcl punctuation.section.braces.end.hcl
+>}
+#^^ source.hcl meta.block.hcl
+>
+>locals {
+#^^^^^^ source.hcl meta.block.hcl variable.other.readwrite.hcl
+#      ^ source.hcl meta.block.hcl
+#       ^ source.hcl meta.block.hcl meta.braces.hcl punctuation.section.braces.begin.hcl
+>  byte_match_statement_rules = local.enabled && var.byte_match_statement_rules != null ? {
+#^^ source.hcl meta.block.hcl meta.braces.hcl
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.mapping.key.hcl variable.other.readwrite.hcl
+#                            ^ source.hcl meta.block.hcl meta.braces.hcl
+#                             ^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.assignment.hcl
+#                              ^ source.hcl meta.block.hcl meta.braces.hcl
+#                               ^^^^^^^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl
+#                                             ^^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.logical.hcl
+#                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl
+#                                                                               ^^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.hcl
+#                                                                                 ^ source.hcl meta.block.hcl meta.braces.hcl
+#                                                                                  ^^^^ source.hcl meta.block.hcl meta.braces.hcl constant.language.hcl
+#                                                                                      ^ source.hcl meta.block.hcl meta.braces.hcl
+#                                                                                       ^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.hcl
+#                                                                                        ^ source.hcl meta.block.hcl meta.braces.hcl
+#                                                                                         ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl punctuation.section.braces.begin.hcl
+>    for rule in flatten(var.byte_match_statement_rules) :
+#^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl
+#    ^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl keyword.control.hcl
+#       ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl
+#        ^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl variable.other.readwrite.hcl
+#            ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl
+#             ^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl keyword.operator.word.hcl
+#               ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl
+#                ^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl support.function.builtin.hcl
+#                       ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
+#                        ^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl
+#                           ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl keyword.operator.accessor.hcl
+#                            ^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl variable.other.member.hcl
+#                                                      ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
+#                                                       ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl
+#                                                        ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl keyword.operator.hcl
+>    format("%s-%s",
+#^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl
+#    ^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl support.function.builtin.hcl
+#          ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
+#           ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#            ^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl string.quoted.double.hcl
+#                 ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                  ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl punctuation.separator.hcl
+>      lookup(rule, "name", null) != null ? rule.name : format("%s-byte-match-%d", module.this.id, rule.priority),
+#^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl
+#      ^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl support.function.builtin.hcl
+#            ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
+#             ^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl
+#                 ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl punctuation.separator.hcl
+#                  ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl
+#                   ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                    ^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl string.quoted.double.hcl
+#                        ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                         ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl punctuation.separator.hcl
+#                          ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl
+#                           ^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl constant.language.hcl
+#                               ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
+#                                ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl
+#                                 ^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl keyword.operator.hcl
+#                                   ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl
+#                                    ^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl constant.language.hcl
+#                                        ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl
+#                                         ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl keyword.operator.hcl
+#                                          ^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl
+#                                               ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl keyword.operator.accessor.hcl
+#                                                ^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl variable.other.member.hcl
+#                                                    ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl
+#                                                     ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl keyword.operator.hcl
+#                                                      ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl
+#                                                       ^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl support.function.builtin.hcl
+#                                                             ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl punctuation.section.parens.begin.hcl
+#                                                              ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                                                               ^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl string.quoted.double.hcl
+#                                                                               ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                                                                                ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl punctuation.separator.hcl
+#                                                                                 ^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl
+#                                                                                        ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl keyword.operator.accessor.hcl
+#                                                                                         ^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl variable.other.member.hcl
+#                                                                                             ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl keyword.operator.accessor.hcl
+#                                                                                              ^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl variable.other.member.hcl
+#                                                                                                ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl punctuation.separator.hcl
+#                                                                                                 ^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl
+#                                                                                                      ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl keyword.operator.accessor.hcl
+#                                                                                                       ^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl variable.other.member.hcl
+#                                                                                                               ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
+#                                                                                                                ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl punctuation.separator.hcl
+>      rule.action,
+#^^^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl
+#          ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl keyword.operator.accessor.hcl
+#           ^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl variable.other.member.hcl
+#                 ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl punctuation.separator.hcl
+>    ) => rule
+#^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl
+#    ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl meta.function-call.hcl punctuation.section.parens.end.hcl
+#     ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl
+#      ^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl keyword.operator.hcl
+#        ^^^^^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl
+>  } : {}
+#^^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl
+#  ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl punctuation.section.braces.end.hcl
+#   ^ source.hcl meta.block.hcl meta.braces.hcl
+#    ^ source.hcl meta.block.hcl meta.braces.hcl keyword.operator.hcl
+#     ^ source.hcl meta.block.hcl meta.braces.hcl
+#      ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl punctuation.section.braces.begin.hcl
+#       ^ source.hcl meta.block.hcl meta.braces.hcl meta.braces.hcl punctuation.section.braces.end.hcl
+>}
+#^ source.hcl meta.block.hcl meta.braces.hcl punctuation.section.braces.end.hcl
+>
+>
+>
+>


### PR DESCRIPTION
This PR improves the inline-for regex, which used to break the highlighting of the rest of the file because it was never terminated.

In the old structure, the `end: \n` regex never matched the end of the line in the example, because the `object` repository would consume the `{` at the end of the line (including the newline). By changing this to a single `match` regex, we can now match the entire line and then delegate the second capture expression to the `for_expression_body` as before.

This shouldn't affect any of our existing tests related to `for`-expressions.

## UX Before
<img width="1139" alt="CleanShot 2024-03-28 at 17 15 16@2x" src="https://github.com/hashicorp/syntax/assets/45985/efb973fc-f36f-49b1-b0d3-df1902afc3b6">

## UX After
<img width="1134" alt="CleanShot 2024-03-28 at 17 14 46@2x" src="https://github.com/hashicorp/syntax/assets/45985/770ffe06-2cec-4c16-8db7-ea16ada175f8">

Closes #113 