### PR TITLE
Allow curly braces in block label strings

### DIFF
--- a/src/_main.yml
+++ b/src/_main.yml
@@ -76,7 +76,7 @@ repository:
   block:
     name: meta.block.hcl
     comment: This will match HCL blocks like `thing1 "one" "two" {` or `thing2 {`
-    begin: ([\w][\-\w]*)([^?{\r\n]*)(\{)
+    begin: ([\w][\-\w]*)([^?\r\n]*)(\{)
     beginCaptures:
       "1":
         patterns:

--- a/syntaxes/hcl.tmGrammar.json
+++ b/syntaxes/hcl.tmGrammar.json
@@ -82,7 +82,7 @@
     },
     "block": {
       "name": "meta.block.hcl",
-      "begin": "([\\w][\\-\\w]*)([^?{\\r\\n]*)(\\{)",
+      "begin": "([\\w][\\-\\w]*)([^?\\r\\n]*)(\\{)",
       "end": "\\}",
       "comment": "This will match HCL blocks like `thing1 \"one\" \"two\" {` or `thing2 {`",
       "beginCaptures": {

--- a/tests/snapshot/hcl/block_labels.hcl
+++ b/tests/snapshot/hcl/block_labels.hcl
@@ -47,3 +47,12 @@ block-single-char-indentifier-newline a {
 }
 
 byte_match_statement_rules = local.enabled && var.byte_match_statement_rules != null ? {
+}
+
+path "secrets/data/users/{{identity.entity.name}}/*" {
+  capabilities = ["create", "update", "patch", "read", "delete", "list"]
+}
+
+path "secrets/data/users/*" {
+  capabilities = ["create", "update", "patch", "read", "delete", "list"]
+}

--- a/tests/snapshot/hcl/block_labels.hcl.snap
+++ b/tests/snapshot/hcl/block_labels.hcl.snap
@@ -268,28 +268,90 @@
 >
 >path "secrets/data/users/{{identity.entity.name}}/*" {
 #^^^^ source.hcl meta.block.hcl entity.name.type.hcl
-#    ^^ source.hcl meta.block.hcl
-#      ^^^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
-#             ^ source.hcl meta.block.hcl
-#              ^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
-#                  ^ source.hcl meta.block.hcl
-#                   ^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
-#                        ^ source.hcl meta.block.hcl
-#                         ^ source.hcl meta.block.hcl punctuation.section.block.begin.hcl
-#                          ^ source.hcl meta.block.hcl meta.braces.hcl punctuation.section.braces.begin.hcl
-#                           ^^^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl
-#                                               ^ source.hcl meta.block.hcl meta.braces.hcl punctuation.section.braces.end.hcl
-#                                                ^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
-#                                                 ^^ source.hcl comment.block.hcl punctuation.definition.comment.hcl
-#                                                   ^^^^ source.hcl comment.block.hcl
+#    ^ source.hcl meta.block.hcl
+#     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                                                    ^ source.hcl meta.block.hcl
+#                                                     ^ source.hcl meta.block.hcl punctuation.section.block.begin.hcl
 >  capabilities = ["create", "update", "patch", "read", "delete", "list"]
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl comment.block.hcl
+#^^ source.hcl meta.block.hcl
+#  ^^^^^^^^^^^^ source.hcl meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#              ^ source.hcl meta.block.hcl variable.declaration.hcl
+#               ^ source.hcl meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#                ^ source.hcl meta.block.hcl variable.declaration.hcl
+#                 ^ source.hcl meta.block.hcl punctuation.section.brackets.begin.hcl
+#                  ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                   ^^^^^^ source.hcl meta.block.hcl string.quoted.double.hcl
+#                         ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                          ^ source.hcl meta.block.hcl punctuation.separator.hcl
+#                           ^ source.hcl meta.block.hcl
+#                            ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                             ^^^^^^ source.hcl meta.block.hcl string.quoted.double.hcl
+#                                   ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                                    ^ source.hcl meta.block.hcl punctuation.separator.hcl
+#                                     ^ source.hcl meta.block.hcl
+#                                      ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                                       ^^^^^ source.hcl meta.block.hcl string.quoted.double.hcl
+#                                            ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                                             ^ source.hcl meta.block.hcl punctuation.separator.hcl
+#                                              ^ source.hcl meta.block.hcl
+#                                               ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                                                ^^^^ source.hcl meta.block.hcl string.quoted.double.hcl
+#                                                    ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                                                     ^ source.hcl meta.block.hcl punctuation.separator.hcl
+#                                                      ^ source.hcl meta.block.hcl
+#                                                       ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                                                        ^^^^^^ source.hcl meta.block.hcl string.quoted.double.hcl
+#                                                              ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                                                               ^ source.hcl meta.block.hcl punctuation.separator.hcl
+#                                                                ^ source.hcl meta.block.hcl
+#                                                                 ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                                                                  ^^^^ source.hcl meta.block.hcl string.quoted.double.hcl
+#                                                                      ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                                                                       ^ source.hcl meta.block.hcl punctuation.section.brackets.end.hcl
 >}
-#^^ source.hcl comment.block.hcl
+#^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
 >
 >path "secrets/data/users/*" {
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl comment.block.hcl
+#^^^^ source.hcl meta.block.hcl entity.name.type.hcl
+#    ^ source.hcl meta.block.hcl
+#     ^^^^^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                           ^ source.hcl meta.block.hcl
+#                            ^ source.hcl meta.block.hcl punctuation.section.block.begin.hcl
 >  capabilities = ["create", "update", "patch", "read", "delete", "list"]
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl comment.block.hcl
+#^^ source.hcl meta.block.hcl
+#  ^^^^^^^^^^^^ source.hcl meta.block.hcl variable.declaration.hcl variable.other.readwrite.hcl
+#              ^ source.hcl meta.block.hcl variable.declaration.hcl
+#               ^ source.hcl meta.block.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#                ^ source.hcl meta.block.hcl variable.declaration.hcl
+#                 ^ source.hcl meta.block.hcl punctuation.section.brackets.begin.hcl
+#                  ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                   ^^^^^^ source.hcl meta.block.hcl string.quoted.double.hcl
+#                         ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                          ^ source.hcl meta.block.hcl punctuation.separator.hcl
+#                           ^ source.hcl meta.block.hcl
+#                            ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                             ^^^^^^ source.hcl meta.block.hcl string.quoted.double.hcl
+#                                   ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                                    ^ source.hcl meta.block.hcl punctuation.separator.hcl
+#                                     ^ source.hcl meta.block.hcl
+#                                      ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                                       ^^^^^ source.hcl meta.block.hcl string.quoted.double.hcl
+#                                            ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                                             ^ source.hcl meta.block.hcl punctuation.separator.hcl
+#                                              ^ source.hcl meta.block.hcl
+#                                               ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                                                ^^^^ source.hcl meta.block.hcl string.quoted.double.hcl
+#                                                    ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                                                     ^ source.hcl meta.block.hcl punctuation.separator.hcl
+#                                                      ^ source.hcl meta.block.hcl
+#                                                       ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                                                        ^^^^^^ source.hcl meta.block.hcl string.quoted.double.hcl
+#                                                              ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                                                               ^ source.hcl meta.block.hcl punctuation.separator.hcl
+#                                                                ^ source.hcl meta.block.hcl
+#                                                                 ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                                                                  ^^^^ source.hcl meta.block.hcl string.quoted.double.hcl
+#                                                                      ^ source.hcl meta.block.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+#                                                                       ^ source.hcl meta.block.hcl punctuation.section.brackets.end.hcl
 >}
-#^^ source.hcl comment.block.hcl
+#^ source.hcl meta.block.hcl punctuation.section.block.end.hcl

--- a/tests/snapshot/hcl/block_labels.hcl.snap
+++ b/tests/snapshot/hcl/block_labels.hcl.snap
@@ -263,3 +263,33 @@
 #                                                                                     ^ source.hcl keyword.operator.hcl
 #                                                                                      ^ source.hcl
 #                                                                                       ^ source.hcl meta.braces.hcl punctuation.section.braces.begin.hcl
+>}
+#^ source.hcl meta.braces.hcl punctuation.section.braces.end.hcl
+>
+>path "secrets/data/users/{{identity.entity.name}}/*" {
+#^^^^ source.hcl meta.block.hcl entity.name.type.hcl
+#    ^^ source.hcl meta.block.hcl
+#      ^^^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#             ^ source.hcl meta.block.hcl
+#              ^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                  ^ source.hcl meta.block.hcl
+#                   ^^^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#                        ^ source.hcl meta.block.hcl
+#                         ^ source.hcl meta.block.hcl punctuation.section.block.begin.hcl
+#                          ^ source.hcl meta.block.hcl meta.braces.hcl punctuation.section.braces.begin.hcl
+#                           ^^^^^^^^^^^^^^^^^^^^ source.hcl meta.block.hcl meta.braces.hcl
+#                                               ^ source.hcl meta.block.hcl meta.braces.hcl punctuation.section.braces.end.hcl
+#                                                ^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
+#                                                 ^^ source.hcl comment.block.hcl punctuation.definition.comment.hcl
+#                                                   ^^^^ source.hcl comment.block.hcl
+>  capabilities = ["create", "update", "patch", "read", "delete", "list"]
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl comment.block.hcl
+>}
+#^^ source.hcl comment.block.hcl
+>
+>path "secrets/data/users/*" {
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl comment.block.hcl
+>  capabilities = ["create", "update", "patch", "read", "delete", "list"]
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.hcl comment.block.hcl
+>}
+#^^ source.hcl comment.block.hcl


### PR DESCRIPTION
This PR removes `{` as disallowed character inside block labels to fix an issue with external template strings. Since were dealing with a string here, we can allow most characters.

## UX Before
<img width="691" alt="CleanShot 2024-04-25 at 12 31 40@2x" src="https://github.com/hashicorp/syntax/assets/45985/ca05b0a5-3f58-4bac-a647-d4b955bb26ed">

## UX After
<img width="728" alt="CleanShot 2024-04-25 at 12 31 23@2x" src="https://github.com/hashicorp/syntax/assets/45985/3bd944f7-3840-4594-b16e-d0635379d197">

Closes #119