### PR TITLE
Update sentinel syntax highlighting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+tmp/

--- a/syntaxes/sentinel.tmGrammar.json
+++ b/syntaxes/sentinel.tmGrammar.json
@@ -38,12 +38,7 @@
       "match": "\\b(if|case|for|any|all|filter|map|break|continue|return)\\b"
     },
     {
-      "name": "keyword.operator.symbol.sentinel",
-      "match": "[-+*/%=<>!]"
-    },
-    {
-      "name": "keyword.control.sentinel",
-      "match": "\\b(and|or|contains|in|is|matches|not|xor|else)\\b"
+      "include": "#operators"
     },
     {
       "name": "keyword.other.sentinel",
@@ -122,6 +117,26 @@
         {
           "name": "constant.numeric.number.sentinel",
           "match": "\\b(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))([eE][-+]?[0-9]+)?\\b"
+        }
+      ]
+    },
+    "operators": {
+      "patterns": [
+        {
+          "name": "keyword.operator.symbol.sentinel",
+          "match": "(\\+=|-=|\\*=|\\/=|%=|==|!=|<=|>=)"
+        },
+        {
+          "name": "keyword.operator.symbol.sentinel",
+          "match": "(\\+|-|\\*|\\/|%|<|>|=|!)"
+        },
+        {
+          "name": "keyword.control.sentinel",
+          "match": "\\b(is\bnot\bempty|is\bempty|not\bcontains|not\bmatches|is\bnot)\\b"
+        },
+        {
+          "name": "keyword.control.sentinel",
+          "match": "\\b(and|contains|else|in|is|matches|not|or|xor)\\b"
         }
       ]
     },

--- a/syntaxes/sentinel.tmGrammar.json
+++ b/syntaxes/sentinel.tmGrammar.json
@@ -5,17 +5,7 @@
   "fileTypes": ["sentinel"],
   "patterns": [
     {
-      "name": "comment.line.double-slash.sentinel",
-      "match": "\\/\\/.*$"
-    },
-    {
-      "name": "comment.line.number-sign.sentinel",
-      "match": "#.*$"
-    },
-    {
-      "begin": "/\\*",
-      "end": "\\*/",
-      "name": "comment.line.block.sentinel"
+      "include": "#comments"
     },
     {
       "name": "constant.numeric.hex.sentinel",
@@ -74,6 +64,9 @@
       "match": "\\b(as|default|when)\\b"
     },
     {
+      "name": "string.quoted.double.untitled",
+      "begin": "\"",
+      "end": "\"",
       "patterns": [
         {
           "name": "constant.character.escape.single.sentinel",
@@ -95,14 +88,56 @@
           "name": "constant.character.escape.unicode64.sentinel",
           "match": "\\\\U[a-fA-F0-9]{8}"
         }
-      ],
-      "begin": "\"",
-      "end": "\"",
-      "name": "string.quoted.double.untitled"
+      ]
     },
     {
       "name": "support.function.builtin.sentinel",
       "match": "\\b(append|delete|error|keys|length|print|range|values|int|float|string|bool)\\b"
     }
-  ]
+  ],
+  "repository": {
+    "block_inline_comments": {
+      "name": "comment.block.sentinel",
+      "begin": "/\\*",
+      "end": "\\*/",
+      "captures": {
+        "0": {
+          "name": "punctuation.definition.comment.sentinel"
+        }
+      }
+    },
+    "comments": {
+      "patterns": [
+        {
+          "include": "#hash_line_comments"
+        },
+        {
+          "include": "#double_slash_line_comments"
+        },
+        {
+          "include": "#block_inline_comments"
+        }
+      ]
+    },
+    "double_slash_line_comments": {
+      "name": "comment.line.double-slash.sentinel",
+      "begin": "//",
+      "end": "$\\n?",
+      "captures": {
+        "0": {
+          "name": "punctuation.definition.comment.sentinel"
+        }
+      }
+    },
+    "hash_line_comments": {
+      "name": "comment.line.number-sign.sentinel",
+      "begin": "#",
+      "end": "$\\n?",
+      "captures": {
+        "0": {
+          "name": "punctuation.definition.comment.sentinel"
+        }
+      }
+    }
+  }
 }

--- a/syntaxes/sentinel.tmGrammar.json
+++ b/syntaxes/sentinel.tmGrammar.json
@@ -8,16 +8,7 @@
       "include": "#comments"
     },
     {
-      "name": "constant.numeric.hex.sentinel",
-      "match": "\\b0[xX][a-fA-F0-9]+\\b"
-    },
-    {
-      "name": "constant.numeric.oct.sentinel",
-      "match": "\\b0[0-7]+\\b"
-    },
-    {
-      "name": "constant.numeric.number.sentinel",
-      "match": "\\b(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))([eE][-+]?[0-9]+)?\\b"
+      "include": "#numeric_literals"
     },
     {
       "name": "constant.language.sentinel",
@@ -115,7 +106,23 @@
         }
       }
     },
-   "string_literals": {
+    "numeric_literals": {
+      "patterns": [
+        {
+          "name": "constant.numeric.hex.sentinel",
+          "match": "\\b0[xX][a-fA-F0-9]+\\b"
+        },
+        {
+          "name": "constant.numeric.oct.sentinel",
+          "match": "\\b0[0-7]+\\b"
+        },
+        {
+          "name": "constant.numeric.number.sentinel",
+          "match": "\\b(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))([eE][-+]?[0-9]+)?\\b"
+        }
+      ]
+    },
+    "string_literals": {
       "name": "string.quoted.double.untitled",
       "begin": "\"",
       "end": "\"",

--- a/syntaxes/sentinel.tmGrammar.json
+++ b/syntaxes/sentinel.tmGrammar.json
@@ -64,31 +64,7 @@
       "match": "\\b(as|default|when)\\b"
     },
     {
-      "name": "string.quoted.double.untitled",
-      "begin": "\"",
-      "end": "\"",
-      "patterns": [
-        {
-          "name": "constant.character.escape.single.sentinel",
-          "match": "\\\\[abfnrtv\\\\\"]"
-        },
-        {
-          "name": "constant.character.escape.hex.sentinel",
-          "match": "\\\\x[a-fA-F0-9]+"
-        },
-        {
-          "name": "constant.character.escape.oct.sentinel",
-          "match": "\\\\[0-7]{3}"
-        },
-        {
-          "name": "constant.character.escape.unicode32.sentinel",
-          "match": "\\\\u[a-fA-F0-9]{4}"
-        },
-        {
-          "name": "constant.character.escape.unicode64.sentinel",
-          "match": "\\\\U[a-fA-F0-9]{8}"
-        }
-      ]
+      "include": "#string_literals"
     },
     {
       "name": "support.function.builtin.sentinel",
@@ -138,6 +114,33 @@
           "name": "punctuation.definition.comment.sentinel"
         }
       }
+    },
+   "string_literals": {
+      "name": "string.quoted.double.untitled",
+      "begin": "\"",
+      "end": "\"",
+      "patterns": [
+        {
+          "name": "constant.character.escape.single.sentinel",
+          "match": "\\\\[abfnrtv\\\\\"]"
+        },
+        {
+          "name": "constant.character.escape.hex.sentinel",
+          "match": "\\\\x[a-fA-F0-9]+"
+        },
+        {
+          "name": "constant.character.escape.oct.sentinel",
+          "match": "\\\\[0-7]{3}"
+        },
+        {
+          "name": "constant.character.escape.unicode32.sentinel",
+          "match": "\\\\u[a-fA-F0-9]{4}"
+        },
+        {
+          "name": "constant.character.escape.unicode64.sentinel",
+          "match": "\\\\U[a-fA-F0-9]{8}"
+        }
+      ]
     }
   }
 }

--- a/syntaxes/sentinel.tmGrammar.json
+++ b/syntaxes/sentinel.tmGrammar.json
@@ -52,8 +52,7 @@
       "include": "#string_literals"
     },
     {
-      "name": "support.function.builtin.sentinel",
-      "match": "\\b(append|delete|error|keys|length|print|range|values|int|float|string|bool)\\b"
+      "include": "#functions"
     }
   ],
   "repository": {
@@ -88,6 +87,18 @@
         "0": {
           "name": "punctuation.definition.comment.sentinel"
         }
+      }
+    },
+    "functions": {
+      "match": "\\b(append|compare|delete|error|keys|length|print|range|values|int|float|string|bool)(\\b\\s*\\()",
+      "captures": {
+        "1": {
+          "name": "support.function.builtin.sentinel"
+        },
+        "2": {
+          "name": ""
+        }
+
       }
     },
     "hash_line_comments": {

--- a/syntaxes/sentinel.tmGrammar.json
+++ b/syntaxes/sentinel.tmGrammar.json
@@ -11,8 +11,7 @@
       "include": "#numeric_literals"
     },
     {
-      "name": "constant.language.sentinel",
-      "match": "\\b(true|false|null|undefined)\\b"
+      "include": "#language_constants"
     },
     {
       "captures": {
@@ -105,6 +104,10 @@
           "name": "punctuation.definition.comment.sentinel"
         }
       }
+    },
+    "language_constants": {
+      "name": "constant.language.sentinel",
+      "match": "\\b(true|false|null|undefined)\\b"
     },
     "numeric_literals": {
       "patterns": [

--- a/tests/snapshot/sentinel/basic.sentinel.snap
+++ b/tests/snapshot/sentinel/basic.sentinel.snap
@@ -10,8 +10,7 @@
 #               ^ source.sentinel
 #                ^^^^ source.sentinel keyword.other.sentinel
 #                    ^^^^^^^^ source.sentinel
-#                            ^ source.sentinel keyword.operator.symbol.sentinel
-#                             ^ source.sentinel keyword.operator.symbol.sentinel
+#                            ^^ source.sentinel keyword.operator.symbol.sentinel
 #                              ^ source.sentinel
 #                               ^ source.sentinel constant.numeric.number.sentinel
 #                                ^^^ source.sentinel

--- a/tests/snapshot/sentinel/boolean_expr.sentinel.snap
+++ b/tests/snapshot/sentinel/boolean_expr.sentinel.snap
@@ -25,8 +25,7 @@
 #       ^ source.sentinel
 #        ^^ source.sentinel constant.numeric.number.sentinel
 #          ^ source.sentinel
-#           ^ source.sentinel keyword.operator.symbol.sentinel
-#            ^ source.sentinel keyword.operator.symbol.sentinel
+#           ^^ source.sentinel keyword.operator.symbol.sentinel
 #             ^ source.sentinel
 #              ^ source.sentinel keyword.operator.symbol.sentinel
 #               ^ source.sentinel constant.numeric.number.sentinel
@@ -36,8 +35,7 @@
 #       ^ source.sentinel
 #        ^^ source.sentinel constant.numeric.number.sentinel
 #          ^ source.sentinel
-#           ^ source.sentinel keyword.operator.symbol.sentinel
-#            ^ source.sentinel keyword.operator.symbol.sentinel
+#           ^^ source.sentinel keyword.operator.symbol.sentinel
 #             ^ source.sentinel
 #              ^ source.sentinel keyword.operator.symbol.sentinel
 #               ^ source.sentinel constant.numeric.number.sentinel
@@ -57,8 +55,7 @@
 #       ^ source.sentinel
 #        ^^ source.sentinel constant.numeric.number.sentinel
 #          ^ source.sentinel
-#           ^ source.sentinel keyword.operator.symbol.sentinel
-#            ^ source.sentinel keyword.operator.symbol.sentinel
+#           ^^ source.sentinel keyword.operator.symbol.sentinel
 #             ^ source.sentinel
 #              ^ source.sentinel keyword.operator.symbol.sentinel
 #               ^ source.sentinel constant.numeric.number.sentinel
@@ -78,8 +75,7 @@
 #       ^ source.sentinel
 #        ^^ source.sentinel constant.numeric.number.sentinel
 #          ^ source.sentinel
-#           ^ source.sentinel keyword.operator.symbol.sentinel
-#            ^ source.sentinel keyword.operator.symbol.sentinel
+#           ^^ source.sentinel keyword.operator.symbol.sentinel
 #             ^ source.sentinel
 #              ^ source.sentinel keyword.operator.symbol.sentinel
 #               ^ source.sentinel constant.numeric.number.sentinel

--- a/tests/snapshot/sentinel/boolean_expr.sentinel.snap
+++ b/tests/snapshot/sentinel/boolean_expr.sentinel.snap
@@ -1,5 +1,6 @@
 ># https://developer.hashicorp.com/sentinel/docs/language/boolexpr
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
+#^ source.sentinel comment.line.number-sign.sentinel punctuation.definition.comment.sentinel
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
 >
 >value = (p and q) or r
 #^^^^^^ source.sentinel
@@ -84,7 +85,8 @@
 #               ^ source.sentinel constant.numeric.number.sentinel
 >
 ># Sets
-#^^^^^^ source.sentinel comment.line.number-sign.sentinel
+#^ source.sentinel comment.line.number-sign.sentinel punctuation.definition.comment.sentinel
+# ^^^^^ source.sentinel comment.line.number-sign.sentinel
 >value = [1, 2, 3] contains 2
 #^^^^^^ source.sentinel
 #      ^ source.sentinel keyword.operator.symbol.sentinel
@@ -228,7 +230,8 @@
 #                                        ^ source.sentinel constant.numeric.number.sentinel
 >
 ># Matches
-#^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
+#^ source.sentinel comment.line.number-sign.sentinel punctuation.definition.comment.sentinel
+# ^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
 >value = "test" matches "e"
 #^^^^^^ source.sentinel
 #      ^ source.sentinel keyword.operator.symbol.sentinel
@@ -313,7 +316,8 @@
 #                             ^ source.sentinel string.quoted.double.untitled
 >
 ># Any, All
-#^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
+#^ source.sentinel comment.line.number-sign.sentinel punctuation.definition.comment.sentinel
+# ^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
 >all group.tasks as t { t.driver is "vmware" }
 #^^^ source.sentinel keyword.control.sentinel
 #   ^^^^^^^^^^^^^ source.sentinel
@@ -365,7 +369,8 @@
 #                                                                 ^ source.sentinel string.quoted.double.untitled
 >
 ># Emptiness/Defined
-#^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
+#^ source.sentinel comment.line.number-sign.sentinel punctuation.definition.comment.sentinel
+# ^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
 >value = x is empty
 #^^^^^^ source.sentinel
 #      ^ source.sentinel keyword.operator.symbol.sentinel

--- a/tests/snapshot/sentinel/collections.sentinel.snap
+++ b/tests/snapshot/sentinel/collections.sentinel.snap
@@ -1,20 +1,24 @@
 ># https://developer.hashicorp.com/sentinel/docs/language/collection-operations
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
+#^ source.sentinel comment.line.number-sign.sentinel punctuation.definition.comment.sentinel
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
 >
 ># filter
-#^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
+#^ source.sentinel comment.line.number-sign.sentinel punctuation.definition.comment.sentinel
+# ^^^^^^^ source.sentinel comment.line.number-sign.sentinel
 >filter list as value { condition }      // Single-iterator, list
 #^^^^^^ source.sentinel keyword.control.sentinel
 #      ^^^^^^ source.sentinel
 #            ^^ source.sentinel keyword.other.sentinel
 #              ^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel
-#                                        ^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                                        ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                                          ^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >filter list as idx, value { condition } // Double-iterator, list
 #^^^^^^ source.sentinel keyword.control.sentinel
 #      ^^^^^^ source.sentinel
 #            ^^ source.sentinel keyword.other.sentinel
 #              ^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel
-#                                        ^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                                        ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                                          ^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >
 >filter map as key { condition }         // Single-iterator, map
 #^^^^^^ source.sentinel keyword.control.sentinel
@@ -23,7 +27,8 @@
 #          ^ source.sentinel
 #           ^^ source.sentinel keyword.other.sentinel
 #             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel
-#                                        ^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                                        ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                                          ^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >filter map as key, value { condition }  // Double-iterator, map
 #^^^^^^ source.sentinel keyword.control.sentinel
 #      ^ source.sentinel
@@ -31,10 +36,12 @@
 #          ^ source.sentinel
 #           ^^ source.sentinel keyword.other.sentinel
 #             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel
-#                                        ^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                                        ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                                          ^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >
 ># map
-#^^^^^ source.sentinel comment.line.number-sign.sentinel
+#^ source.sentinel comment.line.number-sign.sentinel punctuation.definition.comment.sentinel
+# ^^^^ source.sentinel comment.line.number-sign.sentinel
 >l = [1, 2]
 #^^ source.sentinel
 #  ^ source.sentinel keyword.operator.symbol.sentinel
@@ -55,7 +62,8 @@
 #                    ^ source.sentinel
 #                     ^ source.sentinel constant.numeric.number.sentinel
 #                      ^^^ source.sentinel
-#                         ^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                         ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                           ^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >
 >m = { "a": "foo", "b": "bar" }
 #^^ source.sentinel
@@ -85,5 +93,6 @@
 #       ^^^ source.sentinel
 #          ^^ source.sentinel keyword.other.sentinel
 #            ^^^^^^^^^^^^ source.sentinel
-#                        ^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                        ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                          ^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >

--- a/tests/snapshot/sentinel/comments.sentinel.snap
+++ b/tests/snapshot/sentinel/comments.sentinel.snap
@@ -1,28 +1,32 @@
 ># https://developer.hashicorp.com/sentinel/docs/language/spec#comments
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
+#^ source.sentinel comment.line.number-sign.sentinel punctuation.definition.comment.sentinel
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
 >
 ># Single line comment
-#^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
+#^ source.sentinel comment.line.number-sign.sentinel punctuation.definition.comment.sentinel
+# ^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
 >comment
 #^^^^^^^^ source.sentinel
 >
 >comment # Single line comment
 #^^^^^^^^ source.sentinel
-#        ^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
+#        ^ source.sentinel comment.line.number-sign.sentinel punctuation.definition.comment.sentinel
+#         ^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
 >
 >// Single line comment
-#^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#  ^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >comment
 #^^^^^^^^ source.sentinel
 >
 >/* multi
-#^^ source.sentinel comment.line.block.sentinel
-#  ^^^^^^^ source.sentinel comment.line.block.sentinel
+#^^ source.sentinel comment.block.sentinel punctuation.definition.comment.sentinel
+#  ^^^^^^^ source.sentinel comment.block.sentinel
 >line
-#^^^^^ source.sentinel comment.line.block.sentinel
+#^^^^^ source.sentinel comment.block.sentinel
 >    comment */
-#^^^^^^^^^^^^ source.sentinel comment.line.block.sentinel
-#            ^^ source.sentinel comment.line.block.sentinel
+#^^^^^^^^^^^^ source.sentinel comment.block.sentinel
+#            ^^ source.sentinel comment.block.sentinel punctuation.definition.comment.sentinel
 >comment
 #^^^^^^^^ source.sentinel
 >

--- a/tests/snapshot/sentinel/conditional.sentinel.snap
+++ b/tests/snapshot/sentinel/conditional.sentinel.snap
@@ -1,8 +1,10 @@
 ># https://developer.hashicorp.com/sentinel/docs/language/conditionals
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
+#^ source.sentinel comment.line.number-sign.sentinel punctuation.definition.comment.sentinel
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
 >
 ># Single line if statements
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
+#^ source.sentinel comment.line.number-sign.sentinel punctuation.definition.comment.sentinel
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
 >if value is 18 { print("condition met") }
 #^^ source.sentinel keyword.control.sentinel
 #  ^^^^^^^ source.sentinel
@@ -44,7 +46,8 @@
 #                                            ^^^^ source.sentinel
 >
 ># Multi-line if statements
-#^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
+#^ source.sentinel comment.line.number-sign.sentinel punctuation.definition.comment.sentinel
+# ^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
 >if value is 18 {
 #^^ source.sentinel keyword.control.sentinel
 #  ^^^^^^^ source.sentinel
@@ -100,7 +103,8 @@
 #^^ source.sentinel
 >
 ># Multi-line if-elseif-else statements
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
+#^ source.sentinel comment.line.number-sign.sentinel punctuation.definition.comment.sentinel
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
 >if value is 18 { print("condition met") } else if value { print("condition met") } else { print("condition met") }
 #^^ source.sentinel keyword.control.sentinel
 #  ^^^^^^^ source.sentinel
@@ -134,7 +138,8 @@
 #                                                                                                               ^^^^ source.sentinel
 >
 ># Multi-line if-elseif-else statements
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
+#^ source.sentinel comment.line.number-sign.sentinel punctuation.definition.comment.sentinel
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
 >if value is 18 {
 #^^ source.sentinel keyword.control.sentinel
 #  ^^^^^^^ source.sentinel
@@ -180,7 +185,8 @@
 #^^ source.sentinel
 >
 >// Case statements
-#^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#  ^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >case x { when "foo", "bar": return true; else: return false }
 #^^^^ source.sentinel keyword.control.sentinel
 #    ^^^^^ source.sentinel

--- a/tests/snapshot/sentinel/functions.sentinel.snap
+++ b/tests/snapshot/sentinel/functions.sentinel.snap
@@ -104,8 +104,7 @@
 #^^^^ source.sentinel
 #    ^^ source.sentinel keyword.control.sentinel
 #      ^^^ source.sentinel
-#         ^ source.sentinel keyword.operator.symbol.sentinel
-#          ^ source.sentinel keyword.operator.symbol.sentinel
+#         ^^ source.sentinel keyword.operator.symbol.sentinel
 #           ^ source.sentinel
 #            ^ source.sentinel constant.numeric.number.sentinel
 #             ^^^ source.sentinel
@@ -121,8 +120,7 @@
 #^^^^ source.sentinel
 #    ^^ source.sentinel keyword.control.sentinel
 #      ^^^ source.sentinel
-#         ^ source.sentinel keyword.operator.symbol.sentinel
-#          ^ source.sentinel keyword.operator.symbol.sentinel
+#         ^^ source.sentinel keyword.operator.symbol.sentinel
 #           ^ source.sentinel
 #            ^ source.sentinel constant.numeric.number.sentinel
 #             ^^^ source.sentinel

--- a/tests/snapshot/sentinel/functions.sentinel.snap
+++ b/tests/snapshot/sentinel/functions.sentinel.snap
@@ -1,5 +1,6 @@
 ># https://developer.hashicorp.com/sentinel/docs/language/functions
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
+#^ source.sentinel comment.line.number-sign.sentinel punctuation.definition.comment.sentinel
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
 >
 >func sum(a, b) {
 #^^^^ source.sentinel keyword.other.sentinel
@@ -77,7 +78,8 @@
 #^^^^ source.sentinel
 #    ^^^^^ source.sentinel support.function.builtin.sentinel
 #         ^^^^ source.sentinel
-#             ^^^^^ source.sentinel comment.line.double-slash.sentinel
+#             ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#               ^^^ source.sentinel comment.line.double-slash.sentinel
 >    return undefined
 #^^^^ source.sentinel
 #    ^^^^^^ source.sentinel keyword.control.sentinel
@@ -89,7 +91,8 @@
 >print(a) // undefined
 #^^^^^ source.sentinel support.function.builtin.sentinel
 #     ^^^^ source.sentinel
-#         ^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#         ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#           ^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >
 >fib = func(x) {
 #^^^^ source.sentinel

--- a/tests/snapshot/sentinel/functions.sentinel.snap
+++ b/tests/snapshot/sentinel/functions.sentinel.snap
@@ -77,7 +77,8 @@
 >    print(a) // 42
 #^^^^ source.sentinel
 #    ^^^^^ source.sentinel support.function.builtin.sentinel
-#         ^^^^ source.sentinel
+#         ^ source.sentinel
+#          ^^^ source.sentinel
 #             ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
 #               ^^^ source.sentinel comment.line.double-slash.sentinel
 >    return undefined
@@ -90,7 +91,8 @@
 >
 >print(a) // undefined
 #^^^^^ source.sentinel support.function.builtin.sentinel
-#     ^^^^ source.sentinel
+#     ^ source.sentinel
+#      ^^^ source.sentinel
 #         ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
 #           ^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >

--- a/tests/snapshot/sentinel/imports.sentinel.snap
+++ b/tests/snapshot/sentinel/imports.sentinel.snap
@@ -1,5 +1,6 @@
 ># https://developer.hashicorp.com/sentinel/docs/language/imports
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
+#^ source.sentinel comment.line.number-sign.sentinel punctuation.definition.comment.sentinel
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
 >
 >import "calendar"
 #^^^^^^ source.sentinel keyword.control.declaration.sentinel

--- a/tests/snapshot/sentinel/inbuilt_funcs.sentinel
+++ b/tests/snapshot/sentinel/inbuilt_funcs.sentinel
@@ -1,0 +1,53 @@
+# https://developer.hashicorp.com/sentinel/docs/functions
+
+append  (foo, bar)
+append = "baz"
+something = append
+
+compare  (foo, bar)
+compare = "baz"
+something = compare
+
+delete  (foo, bar)
+delete = "baz"
+something = delete
+
+error  (foo, bar)
+error = "baz"
+something = error
+
+keys  (foo, bar)
+keys = "baz"
+something = keys
+
+length  (foo, bar)
+length = "baz"
+something = length
+
+print  (foo, bar)
+print = "baz"
+something = print
+
+range  (foo, bar)
+range = "baz"
+something = range
+
+values  (foo, bar)
+values = "baz"
+something = values
+
+int  (foo, bar)
+int = "baz"
+something = int
+
+float  (foo, bar)
+float = "baz"
+something = float
+
+string  (foo, bar)
+string = "baz"
+something = string
+
+bool  (foo, bar)
+bool = "baz"
+something = bool

--- a/tests/snapshot/sentinel/inbuilt_funcs.sentinel.snap
+++ b/tests/snapshot/sentinel/inbuilt_funcs.sentinel.snap
@@ -1,0 +1,212 @@
+># https://developer.hashicorp.com/sentinel/docs/functions
+#^ source.sentinel comment.line.number-sign.sentinel punctuation.definition.comment.sentinel
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
+>
+>append  (foo, bar)
+#^^^^^^ source.sentinel support.function.builtin.sentinel
+#      ^^^ source.sentinel
+#         ^^^^^^^^^^ source.sentinel
+>append = "baz"
+#^^^^^^^ source.sentinel
+#       ^ source.sentinel keyword.operator.symbol.sentinel
+#        ^ source.sentinel
+#         ^ source.sentinel string.quoted.double.untitled
+#          ^^^ source.sentinel string.quoted.double.untitled
+#             ^ source.sentinel string.quoted.double.untitled
+>something = append
+#^^^^^^^^^^ source.sentinel
+#          ^ source.sentinel keyword.operator.symbol.sentinel
+#           ^^^^^^^^ source.sentinel
+>
+>compare  (foo, bar)
+#^^^^^^^ source.sentinel support.function.builtin.sentinel
+#       ^^^ source.sentinel
+#          ^^^^^^^^^^ source.sentinel
+>compare = "baz"
+#^^^^^^^^ source.sentinel
+#        ^ source.sentinel keyword.operator.symbol.sentinel
+#         ^ source.sentinel
+#          ^ source.sentinel string.quoted.double.untitled
+#           ^^^ source.sentinel string.quoted.double.untitled
+#              ^ source.sentinel string.quoted.double.untitled
+>something = compare
+#^^^^^^^^^^ source.sentinel
+#          ^ source.sentinel keyword.operator.symbol.sentinel
+#           ^^^^^^^^^ source.sentinel
+>
+>delete  (foo, bar)
+#^^^^^^ source.sentinel support.function.builtin.sentinel
+#      ^^^ source.sentinel
+#         ^^^^^^^^^^ source.sentinel
+>delete = "baz"
+#^^^^^^^ source.sentinel
+#       ^ source.sentinel keyword.operator.symbol.sentinel
+#        ^ source.sentinel
+#         ^ source.sentinel string.quoted.double.untitled
+#          ^^^ source.sentinel string.quoted.double.untitled
+#             ^ source.sentinel string.quoted.double.untitled
+>something = delete
+#^^^^^^^^^^ source.sentinel
+#          ^ source.sentinel keyword.operator.symbol.sentinel
+#           ^^^^^^^^ source.sentinel
+>
+>error  (foo, bar)
+#^^^^^ source.sentinel support.function.builtin.sentinel
+#     ^^^ source.sentinel
+#        ^^^^^^^^^^ source.sentinel
+>error = "baz"
+#^^^^^^ source.sentinel
+#      ^ source.sentinel keyword.operator.symbol.sentinel
+#       ^ source.sentinel
+#        ^ source.sentinel string.quoted.double.untitled
+#         ^^^ source.sentinel string.quoted.double.untitled
+#            ^ source.sentinel string.quoted.double.untitled
+>something = error
+#^^^^^^^^^^ source.sentinel
+#          ^ source.sentinel keyword.operator.symbol.sentinel
+#           ^^^^^^^ source.sentinel
+>
+>keys  (foo, bar)
+#^^^^ source.sentinel support.function.builtin.sentinel
+#    ^^^ source.sentinel
+#       ^^^^^^^^^^ source.sentinel
+>keys = "baz"
+#^^^^^ source.sentinel
+#     ^ source.sentinel keyword.operator.symbol.sentinel
+#      ^ source.sentinel
+#       ^ source.sentinel string.quoted.double.untitled
+#        ^^^ source.sentinel string.quoted.double.untitled
+#           ^ source.sentinel string.quoted.double.untitled
+>something = keys
+#^^^^^^^^^^ source.sentinel
+#          ^ source.sentinel keyword.operator.symbol.sentinel
+#           ^^^^^^ source.sentinel
+>
+>length  (foo, bar)
+#^^^^^^ source.sentinel support.function.builtin.sentinel
+#      ^^^ source.sentinel
+#         ^^^^^^^^^^ source.sentinel
+>length = "baz"
+#^^^^^^^ source.sentinel
+#       ^ source.sentinel keyword.operator.symbol.sentinel
+#        ^ source.sentinel
+#         ^ source.sentinel string.quoted.double.untitled
+#          ^^^ source.sentinel string.quoted.double.untitled
+#             ^ source.sentinel string.quoted.double.untitled
+>something = length
+#^^^^^^^^^^ source.sentinel
+#          ^ source.sentinel keyword.operator.symbol.sentinel
+#           ^^^^^^^^ source.sentinel
+>
+>print  (foo, bar)
+#^^^^^ source.sentinel support.function.builtin.sentinel
+#     ^^^ source.sentinel
+#        ^^^^^^^^^^ source.sentinel
+>print = "baz"
+#^^^^^^ source.sentinel
+#      ^ source.sentinel keyword.operator.symbol.sentinel
+#       ^ source.sentinel
+#        ^ source.sentinel string.quoted.double.untitled
+#         ^^^ source.sentinel string.quoted.double.untitled
+#            ^ source.sentinel string.quoted.double.untitled
+>something = print
+#^^^^^^^^^^ source.sentinel
+#          ^ source.sentinel keyword.operator.symbol.sentinel
+#           ^^^^^^^ source.sentinel
+>
+>range  (foo, bar)
+#^^^^^ source.sentinel support.function.builtin.sentinel
+#     ^^^ source.sentinel
+#        ^^^^^^^^^^ source.sentinel
+>range = "baz"
+#^^^^^^ source.sentinel
+#      ^ source.sentinel keyword.operator.symbol.sentinel
+#       ^ source.sentinel
+#        ^ source.sentinel string.quoted.double.untitled
+#         ^^^ source.sentinel string.quoted.double.untitled
+#            ^ source.sentinel string.quoted.double.untitled
+>something = range
+#^^^^^^^^^^ source.sentinel
+#          ^ source.sentinel keyword.operator.symbol.sentinel
+#           ^^^^^^^ source.sentinel
+>
+>values  (foo, bar)
+#^^^^^^ source.sentinel support.function.builtin.sentinel
+#      ^^^ source.sentinel
+#         ^^^^^^^^^^ source.sentinel
+>values = "baz"
+#^^^^^^^ source.sentinel
+#       ^ source.sentinel keyword.operator.symbol.sentinel
+#        ^ source.sentinel
+#         ^ source.sentinel string.quoted.double.untitled
+#          ^^^ source.sentinel string.quoted.double.untitled
+#             ^ source.sentinel string.quoted.double.untitled
+>something = values
+#^^^^^^^^^^ source.sentinel
+#          ^ source.sentinel keyword.operator.symbol.sentinel
+#           ^^^^^^^^ source.sentinel
+>
+>int  (foo, bar)
+#^^^ source.sentinel support.function.builtin.sentinel
+#   ^^^ source.sentinel
+#      ^^^^^^^^^^ source.sentinel
+>int = "baz"
+#^^^^ source.sentinel
+#    ^ source.sentinel keyword.operator.symbol.sentinel
+#     ^ source.sentinel
+#      ^ source.sentinel string.quoted.double.untitled
+#       ^^^ source.sentinel string.quoted.double.untitled
+#          ^ source.sentinel string.quoted.double.untitled
+>something = int
+#^^^^^^^^^^ source.sentinel
+#          ^ source.sentinel keyword.operator.symbol.sentinel
+#           ^^^^^ source.sentinel
+>
+>float  (foo, bar)
+#^^^^^ source.sentinel support.function.builtin.sentinel
+#     ^^^ source.sentinel
+#        ^^^^^^^^^^ source.sentinel
+>float = "baz"
+#^^^^^^ source.sentinel
+#      ^ source.sentinel keyword.operator.symbol.sentinel
+#       ^ source.sentinel
+#        ^ source.sentinel string.quoted.double.untitled
+#         ^^^ source.sentinel string.quoted.double.untitled
+#            ^ source.sentinel string.quoted.double.untitled
+>something = float
+#^^^^^^^^^^ source.sentinel
+#          ^ source.sentinel keyword.operator.symbol.sentinel
+#           ^^^^^^^ source.sentinel
+>
+>string  (foo, bar)
+#^^^^^^ source.sentinel support.function.builtin.sentinel
+#      ^^^ source.sentinel
+#         ^^^^^^^^^^ source.sentinel
+>string = "baz"
+#^^^^^^^ source.sentinel
+#       ^ source.sentinel keyword.operator.symbol.sentinel
+#        ^ source.sentinel
+#         ^ source.sentinel string.quoted.double.untitled
+#          ^^^ source.sentinel string.quoted.double.untitled
+#             ^ source.sentinel string.quoted.double.untitled
+>something = string
+#^^^^^^^^^^ source.sentinel
+#          ^ source.sentinel keyword.operator.symbol.sentinel
+#           ^^^^^^^^ source.sentinel
+>
+>bool  (foo, bar)
+#^^^^ source.sentinel support.function.builtin.sentinel
+#    ^^^ source.sentinel
+#       ^^^^^^^^^^ source.sentinel
+>bool = "baz"
+#^^^^^ source.sentinel
+#     ^ source.sentinel keyword.operator.symbol.sentinel
+#      ^ source.sentinel
+#       ^ source.sentinel string.quoted.double.untitled
+#        ^^^ source.sentinel string.quoted.double.untitled
+#           ^ source.sentinel string.quoted.double.untitled
+>something = bool
+#^^^^^^^^^^ source.sentinel
+#          ^ source.sentinel keyword.operator.symbol.sentinel
+#           ^^^^^^ source.sentinel
+>

--- a/tests/snapshot/sentinel/lists.sentinel.snap
+++ b/tests/snapshot/sentinel/lists.sentinel.snap
@@ -1,16 +1,19 @@
 ># https://developer.hashicorp.com/sentinel/docs/language/lists
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
+#^ source.sentinel comment.line.number-sign.sentinel punctuation.definition.comment.sentinel
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
 >
 >[]                  // An empty list
 #^^^^^^^^^^^^^^^^^^^^ source.sentinel
-#                    ^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                    ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                      ^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >["foo"]             // Single element list
 #^ source.sentinel
 # ^ source.sentinel string.quoted.double.untitled
 #  ^^^ source.sentinel string.quoted.double.untitled
 #     ^ source.sentinel string.quoted.double.untitled
 #      ^^^^^^^^^^^^^^ source.sentinel
-#                    ^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                    ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                      ^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >["foo", 1, 2, true] // Multi element list with different types
 #^ source.sentinel
 # ^ source.sentinel string.quoted.double.untitled
@@ -23,7 +26,8 @@
 #            ^^ source.sentinel
 #              ^^^^ source.sentinel constant.language.sentinel
 #                  ^^ source.sentinel
-#                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                    ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >["foo", [1, 2]]     // List containing another list
 #^ source.sentinel
 # ^ source.sentinel string.quoted.double.untitled
@@ -34,7 +38,8 @@
 #          ^^ source.sentinel
 #            ^ source.sentinel constant.numeric.number.sentinel
 #             ^^^^^^^ source.sentinel
-#                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                    ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >
 >
 >value = append([1,2], 3)      // [1, 2, 3]
@@ -49,7 +54,8 @@
 #                   ^^^ source.sentinel
 #                      ^ source.sentinel constant.numeric.number.sentinel
 #                       ^^^^^^^ source.sentinel
-#                              ^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                              ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                                ^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >value = append([1,2], "foo")  // [1, 2, "foo"]
 #^^^^^^ source.sentinel
 #      ^ source.sentinel keyword.operator.symbol.sentinel
@@ -64,7 +70,8 @@
 #                       ^^^ source.sentinel string.quoted.double.untitled
 #                          ^ source.sentinel string.quoted.double.untitled
 #                           ^^^ source.sentinel
-#                              ^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                              ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                                ^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >value = append([1,2], [3])    // [1, 2, [3]]
 #^^^^^^ source.sentinel
 #      ^ source.sentinel keyword.operator.symbol.sentinel
@@ -77,7 +84,8 @@
 #                   ^^^^ source.sentinel
 #                       ^ source.sentinel constant.numeric.number.sentinel
 #                        ^^^^^^ source.sentinel
-#                              ^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                              ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                                ^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >value = append(1, 3)          // error()
 #^^^^^^ source.sentinel
 #      ^ source.sentinel keyword.operator.symbol.sentinel
@@ -88,7 +96,8 @@
 #                ^^ source.sentinel
 #                  ^ source.sentinel constant.numeric.number.sentinel
 #                   ^^^^^^^^^^^ source.sentinel
-#                              ^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                              ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                                ^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >
 >[1, 2] is [1, 2]                       // true
 #^ source.sentinel
@@ -102,7 +111,8 @@
 #            ^^ source.sentinel
 #              ^ source.sentinel constant.numeric.number.sentinel
 #               ^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel
-#                                       ^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                                       ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                                         ^^^^^ source.sentinel comment.line.double-slash.sentinel
 >[1, 2] is [2, 1]                       // false
 #^ source.sentinel
 # ^ source.sentinel constant.numeric.number.sentinel
@@ -115,7 +125,8 @@
 #            ^^ source.sentinel
 #              ^ source.sentinel constant.numeric.number.sentinel
 #               ^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel
-#                                       ^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                                       ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                                         ^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >["a"] is ["a", "b"]                    // false
 #^ source.sentinel
 # ^ source.sentinel string.quoted.double.untitled
@@ -132,7 +143,8 @@
 #                ^ source.sentinel string.quoted.double.untitled
 #                 ^ source.sentinel string.quoted.double.untitled
 #                  ^^^^^^^^^^^^^^^^^^^^^ source.sentinel
-#                                       ^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                                       ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                                         ^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >["a", ["b", "c"]] is ["a", ["b", "c"]] // true
 #^ source.sentinel
 # ^ source.sentinel string.quoted.double.untitled
@@ -161,5 +173,6 @@
 #                                  ^ source.sentinel string.quoted.double.untitled
 #                                   ^ source.sentinel string.quoted.double.untitled
 #                                    ^^^ source.sentinel
-#                                       ^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                                       ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                                         ^^^^^ source.sentinel comment.line.double-slash.sentinel
 >

--- a/tests/snapshot/sentinel/lists.sentinel.snap
+++ b/tests/snapshot/sentinel/lists.sentinel.snap
@@ -47,7 +47,8 @@
 #      ^ source.sentinel keyword.operator.symbol.sentinel
 #       ^ source.sentinel
 #        ^^^^^^ source.sentinel support.function.builtin.sentinel
-#              ^^ source.sentinel
+#              ^ source.sentinel
+#               ^ source.sentinel
 #                ^ source.sentinel constant.numeric.number.sentinel
 #                 ^ source.sentinel
 #                  ^ source.sentinel constant.numeric.number.sentinel
@@ -61,7 +62,8 @@
 #      ^ source.sentinel keyword.operator.symbol.sentinel
 #       ^ source.sentinel
 #        ^^^^^^ source.sentinel support.function.builtin.sentinel
-#              ^^ source.sentinel
+#              ^ source.sentinel
+#               ^ source.sentinel
 #                ^ source.sentinel constant.numeric.number.sentinel
 #                 ^ source.sentinel
 #                  ^ source.sentinel constant.numeric.number.sentinel
@@ -77,7 +79,8 @@
 #      ^ source.sentinel keyword.operator.symbol.sentinel
 #       ^ source.sentinel
 #        ^^^^^^ source.sentinel support.function.builtin.sentinel
-#              ^^ source.sentinel
+#              ^ source.sentinel
+#               ^ source.sentinel
 #                ^ source.sentinel constant.numeric.number.sentinel
 #                 ^ source.sentinel
 #                  ^ source.sentinel constant.numeric.number.sentinel

--- a/tests/snapshot/sentinel/logging_errors.sentinel.snap
+++ b/tests/snapshot/sentinel/logging_errors.sentinel.snap
@@ -1,5 +1,6 @@
 ># https://developer.hashicorp.com/sentinel/docs/language/logging-errors
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
+#^ source.sentinel comment.line.number-sign.sentinel punctuation.definition.comment.sentinel
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
 >
 >value = 42
 #^^^^^^ source.sentinel
@@ -13,7 +14,8 @@
 #       ^^^^^^^^^^^^ source.sentinel string.quoted.double.untitled
 #                   ^ source.sentinel string.quoted.double.untitled
 #                    ^^^^^^^^^ source.sentinel
-#                             ^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                             ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                               ^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >
 >map = { "foo": false }
 #^^^ source.sentinel keyword.control.sentinel
@@ -31,7 +33,8 @@
 #     ^ source.sentinel
 #      ^^^ source.sentinel keyword.control.sentinel
 #         ^^ source.sentinel
-#           ^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#           ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#             ^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >
 >one_is_zero = rule { 1 == 0 }
 #^^^^^^^^^^^^ source.sentinel
@@ -49,5 +52,6 @@
 >print(one_is_zero) // false
 #^^^^^ source.sentinel support.function.builtin.sentinel
 #     ^^^^^^^^^^^^^^ source.sentinel
-#                   ^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                   ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                     ^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >

--- a/tests/snapshot/sentinel/logging_errors.sentinel.snap
+++ b/tests/snapshot/sentinel/logging_errors.sentinel.snap
@@ -50,7 +50,8 @@
 #                           ^^^ source.sentinel
 >print(one_is_zero) // false
 #^^^^^ source.sentinel support.function.builtin.sentinel
-#     ^^^^^^^^^^^^^^ source.sentinel
+#     ^ source.sentinel
+#      ^^^^^^^^^^^^^ source.sentinel
 #                   ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
 #                     ^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >

--- a/tests/snapshot/sentinel/logging_errors.sentinel.snap
+++ b/tests/snapshot/sentinel/logging_errors.sentinel.snap
@@ -44,8 +44,7 @@
 #                  ^^^ source.sentinel
 #                     ^ source.sentinel constant.numeric.number.sentinel
 #                      ^ source.sentinel
-#                       ^ source.sentinel keyword.operator.symbol.sentinel
-#                        ^ source.sentinel keyword.operator.symbol.sentinel
+#                       ^^ source.sentinel keyword.operator.symbol.sentinel
 #                         ^ source.sentinel
 #                          ^ source.sentinel constant.numeric.number.sentinel
 #                           ^^^ source.sentinel

--- a/tests/snapshot/sentinel/loops.sentinel.snap
+++ b/tests/snapshot/sentinel/loops.sentinel.snap
@@ -22,7 +22,8 @@
 >    append(list, name)
 #^^^^ source.sentinel
 #    ^^^^^^ source.sentinel support.function.builtin.sentinel
-#          ^^^^^^^^^^^^^ source.sentinel
+#          ^ source.sentinel
+#           ^^^^^^^^^^^^ source.sentinel
 >}
 #^^ source.sentinel
 >

--- a/tests/snapshot/sentinel/loops.sentinel.snap
+++ b/tests/snapshot/sentinel/loops.sentinel.snap
@@ -61,8 +61,7 @@
 #                ^^^^^^^ source.sentinel
 >    count += num
 #^^^^^^^^^^ source.sentinel
-#          ^ source.sentinel keyword.operator.symbol.sentinel
-#           ^ source.sentinel keyword.operator.symbol.sentinel
+#          ^^ source.sentinel keyword.operator.symbol.sentinel
 #            ^^^^^ source.sentinel
 >}
 #^^ source.sentinel

--- a/tests/snapshot/sentinel/loops.sentinel.snap
+++ b/tests/snapshot/sentinel/loops.sentinel.snap
@@ -1,5 +1,6 @@
 ># https://developer.hashicorp.com/sentinel/docs/language/loops
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
+#^ source.sentinel comment.line.number-sign.sentinel punctuation.definition.comment.sentinel
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
 >
 >for { "a": 1, "b": 2 } as name {
 #^^^ source.sentinel keyword.control.sentinel

--- a/tests/snapshot/sentinel/maps.sentinel.snap
+++ b/tests/snapshot/sentinel/maps.sentinel.snap
@@ -1,13 +1,16 @@
 ># https://developer.hashicorp.com/sentinel/docs/language/maps
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
+#^ source.sentinel comment.line.number-sign.sentinel punctuation.definition.comment.sentinel
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
 >
 >// Empty map
-#^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#  ^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >{}
 #^^^ source.sentinel
 >
 >// Map with a single value on one line
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >{ "key": "value" }
 #^^ source.sentinel
 #  ^ source.sentinel string.quoted.double.untitled
@@ -20,7 +23,8 @@
 #                ^^^ source.sentinel
 >
 >// Map with multiple values with differing types on multiple lines
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >{
 #^^ source.sentinel
 >		"key": "value",
@@ -66,18 +70,21 @@
 #     ^^^ source.sentinel string.quoted.double.untitled
 #        ^ source.sentinel string.quoted.double.untitled
 #         ^^ source.sentinel
-#           ^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#           ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#             ^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >foo[42]    // true
 #^^^^ source.sentinel
 #    ^^ source.sentinel constant.numeric.number.sentinel
 #      ^^^^^ source.sentinel
-#           ^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#           ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#             ^^^^^ source.sentinel comment.line.double-slash.sentinel
 >map[0]     // undefined
 #^^^ source.sentinel keyword.control.sentinel
 #   ^ source.sentinel
 #    ^ source.sentinel constant.numeric.number.sentinel
 #     ^^^^^^ source.sentinel
-#           ^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#           ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#             ^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >
 >map = { "key": "value" }
 #^^^ source.sentinel keyword.control.sentinel
@@ -102,7 +109,8 @@
 #         ^ source.sentinel
 #          ^^^^ source.sentinel constant.language.sentinel
 #              ^^^ source.sentinel
-#                 ^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                 ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                   ^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >map["key"] = 12  // Modify the value of "key"
 #^^^ source.sentinel keyword.control.sentinel
 #   ^ source.sentinel
@@ -114,7 +122,8 @@
 #            ^ source.sentinel
 #             ^^ source.sentinel constant.numeric.number.sentinel
 #               ^^ source.sentinel
-#                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                 ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                   ^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >
 >
 >map = { "key": "value" }
@@ -139,7 +148,8 @@
 #             ^^^ source.sentinel string.quoted.double.untitled
 #                ^ source.sentinel string.quoted.double.untitled
 #                 ^^^^^ source.sentinel
-#                      ^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                      ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                        ^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >delete(map, "other")  // no effect for non-existent key
 #^^^^^^ source.sentinel support.function.builtin.sentinel
 #      ^ source.sentinel
@@ -149,7 +159,8 @@
 #             ^^^^^ source.sentinel string.quoted.double.untitled
 #                  ^ source.sentinel string.quoted.double.untitled
 #                   ^^^ source.sentinel
-#                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                      ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >
 >
 >data = { "a": 2, "b": 3 }
@@ -171,11 +182,13 @@
 >keys(data)       // ["b", "a"]
 #^^^^ source.sentinel support.function.builtin.sentinel
 #    ^^^^^^^^^^^^^ source.sentinel
-#                 ^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                 ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                   ^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >values(data)     // [2, 3]
 #^^^^^^ source.sentinel support.function.builtin.sentinel
 #      ^^^^^^^^^^^ source.sentinel
-#                 ^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                 ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                   ^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >
 >{"foo": "bar"} is {"foo": "bar"}               // true
 #^ source.sentinel
@@ -197,7 +210,8 @@
 #                           ^^^ source.sentinel string.quoted.double.untitled
 #                              ^ source.sentinel string.quoted.double.untitled
 #                               ^^^^^^^^^^^^^^^^ source.sentinel
-#                                               ^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                                               ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                                                 ^^^^^ source.sentinel comment.line.double-slash.sentinel
 >{"foo": "bar"} is {"baz": "bar"}               // false
 #^ source.sentinel
 # ^ source.sentinel string.quoted.double.untitled
@@ -218,7 +232,8 @@
 #                           ^^^ source.sentinel string.quoted.double.untitled
 #                              ^ source.sentinel string.quoted.double.untitled
 #                               ^^^^^^^^^^^^^^^^ source.sentinel
-#                                               ^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                                               ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                                                 ^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >{"foo": "bar"} is {"foo": "baz"}               // false
 #^ source.sentinel
 # ^ source.sentinel string.quoted.double.untitled
@@ -239,7 +254,8 @@
 #                           ^^^ source.sentinel string.quoted.double.untitled
 #                              ^ source.sentinel string.quoted.double.untitled
 #                               ^^^^^^^^^^^^^^^^ source.sentinel
-#                                               ^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                                               ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                                                 ^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >{"foo": "bar"} is {"foo": "bar", "baz": "qux"} // false
 #^ source.sentinel
 # ^ source.sentinel string.quoted.double.untitled
@@ -268,7 +284,8 @@
 #                                         ^^^ source.sentinel string.quoted.double.untitled
 #                                            ^ source.sentinel string.quoted.double.untitled
 #                                             ^^ source.sentinel
-#                                               ^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                                               ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                                                 ^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >{1: "a"} is {1.0: "a"}                         // true (int/float comparable)
 #^ source.sentinel
 # ^ source.sentinel constant.numeric.number.sentinel
@@ -285,10 +302,12 @@
 #                   ^ source.sentinel string.quoted.double.untitled
 #                    ^ source.sentinel string.quoted.double.untitled
 #                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel
-#                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                                               ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >
 >// also true (maps are not ordered):
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >{"m": {"a": "b"}, "l": ["a"]} is {"l": ["a"], "m": {"a": " b"}}
 #^ source.sentinel
 # ^ source.sentinel string.quoted.double.untitled

--- a/tests/snapshot/sentinel/maps.sentinel.snap
+++ b/tests/snapshot/sentinel/maps.sentinel.snap
@@ -181,12 +181,14 @@
 #                       ^^^ source.sentinel
 >keys(data)       // ["b", "a"]
 #^^^^ source.sentinel support.function.builtin.sentinel
-#    ^^^^^^^^^^^^^ source.sentinel
+#    ^ source.sentinel
+#     ^^^^^^^^^^^^ source.sentinel
 #                 ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
 #                   ^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >values(data)     // [2, 3]
 #^^^^^^ source.sentinel support.function.builtin.sentinel
-#      ^^^^^^^^^^^ source.sentinel
+#      ^ source.sentinel
+#       ^^^^^^^^^^ source.sentinel
 #                 ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
 #                   ^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >

--- a/tests/snapshot/sentinel/maths.sentinel.snap
+++ b/tests/snapshot/sentinel/maths.sentinel.snap
@@ -1,5 +1,6 @@
 ># https://developer.hashicorp.com/sentinel/docs/language/arithmetic
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
+#^ source.sentinel comment.line.number-sign.sentinel punctuation.definition.comment.sentinel
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
 >value = 4 + 8
 #^^^^^^ source.sentinel
 #      ^ source.sentinel keyword.operator.symbol.sentinel

--- a/tests/snapshot/sentinel/params.sentinel.snap
+++ b/tests/snapshot/sentinel/params.sentinel.snap
@@ -1,5 +1,6 @@
 ># https://developer.hashicorp.com/sentinel/docs/language/parameters
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
+#^ source.sentinel comment.line.number-sign.sentinel punctuation.definition.comment.sentinel
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
 >
 >param foo
 #^^^^^ source.sentinel keyword.control.declaration.sentinel

--- a/tests/snapshot/sentinel/rules.sentinel.snap
+++ b/tests/snapshot/sentinel/rules.sentinel.snap
@@ -1,5 +1,6 @@
 ># https://developer.hashicorp.com/sentinel/docs/language/rules
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
+#^ source.sentinel comment.line.number-sign.sentinel punctuation.definition.comment.sentinel
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
 >
 >main = rule {
 #^^^^^ source.sentinel

--- a/tests/snapshot/sentinel/slices.sentinel.snap
+++ b/tests/snapshot/sentinel/slices.sentinel.snap
@@ -1,5 +1,6 @@
 ># https://developer.hashicorp.com/sentinel/docs/language/slices
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
+#^ source.sentinel comment.line.number-sign.sentinel punctuation.definition.comment.sentinel
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
 >a = [1, 2, 3, 4, 5]
 #^^ source.sentinel
 #  ^ source.sentinel keyword.operator.symbol.sentinel

--- a/tests/snapshot/sentinel/undefined.sentinel.snap
+++ b/tests/snapshot/sentinel/undefined.sentinel.snap
@@ -35,8 +35,7 @@
 #          ^ source.sentinel
 #           ^^ source.sentinel constant.numeric.number.sentinel
 #             ^ source.sentinel
-#              ^ source.sentinel keyword.operator.symbol.sentinel
-#               ^ source.sentinel keyword.operator.symbol.sentinel
+#              ^^ source.sentinel keyword.operator.symbol.sentinel
 #                ^ source.sentinel
 #                 ^^ source.sentinel constant.numeric.number.sentinel
 >a = config.value else "default"

--- a/tests/snapshot/sentinel/undefined.sentinel.snap
+++ b/tests/snapshot/sentinel/undefined.sentinel.snap
@@ -1,5 +1,6 @@
 ># https://developer.hashicorp.com/sentinel/docs/language/undefined
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
+#^ source.sentinel comment.line.number-sign.sentinel punctuation.definition.comment.sentinel
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
 >
 >foo() else 42
 #^^^^^^ source.sentinel
@@ -25,7 +26,8 @@
 #                               ^ source.sentinel string.quoted.double.untitled
 >
 >// In more complex scenarios
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >
 >foo() else 42 == 12
 #^^^^^^ source.sentinel

--- a/tests/snapshot/sentinel/values.sentinel.snap
+++ b/tests/snapshot/sentinel/values.sentinel.snap
@@ -1,8 +1,10 @@
 ># https://developer.hashicorp.com/sentinel/docs/language/values
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
+#^ source.sentinel comment.line.number-sign.sentinel punctuation.definition.comment.sentinel
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
 >
 ># Int
-#^^^^^ source.sentinel comment.line.number-sign.sentinel
+#^ source.sentinel comment.line.number-sign.sentinel punctuation.definition.comment.sentinel
+# ^^^^ source.sentinel comment.line.number-sign.sentinel
 >value = 42
 #^^^^^^ source.sentinel
 #      ^ source.sentinel keyword.operator.symbol.sentinel
@@ -25,7 +27,8 @@
 #        ^^^^^^^^^^^^^^^ source.sentinel constant.numeric.number.sentinel
 >
 ># Float
-#^^^^^^^ source.sentinel comment.line.number-sign.sentinel
+#^ source.sentinel comment.line.number-sign.sentinel punctuation.definition.comment.sentinel
+# ^^^^^^ source.sentinel comment.line.number-sign.sentinel
 >value = 0.
 #^^^^^^ source.sentinel
 #      ^ source.sentinel keyword.operator.symbol.sentinel
@@ -44,7 +47,8 @@
 #        ^^^ source.sentinel constant.numeric.oct.sentinel
 #           ^^^ source.sentinel constant.numeric.number.sentinel
 #              ^^ source.sentinel
-#                ^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                  ^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >value = 2.71828
 #^^^^^^ source.sentinel
 #      ^ source.sentinel keyword.operator.symbol.sentinel
@@ -77,7 +81,8 @@
 #         ^^^^^^^^ source.sentinel constant.numeric.number.sentinel
 >
 ># Strings
-#^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
+#^ source.sentinel comment.line.number-sign.sentinel punctuation.definition.comment.sentinel
+# ^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
 >value = "\n"
 #^^^^^^ source.sentinel
 #      ^ source.sentinel keyword.operator.symbol.sentinel
@@ -93,7 +98,8 @@
 #         ^^ source.sentinel string.quoted.double.untitled constant.character.escape.single.sentinel
 #           ^ source.sentinel string.quoted.double.untitled
 #            ^^^^^^^^^^^^^^^^^ source.sentinel
-#                             ^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                             ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                               ^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >value = "Hello, world!\n"
 #^^^^^^ source.sentinel
 #      ^ source.sentinel keyword.operator.symbol.sentinel
@@ -134,7 +140,8 @@
 #         ^^^^^^ source.sentinel string.quoted.double.untitled constant.character.escape.unicode32.sentinel
 #               ^ source.sentinel string.quoted.double.untitled
 #                ^^^^^^^^^^^^^ source.sentinel
-#                             ^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                             ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                               ^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >value = "\U00110000"         // illegal: invalid Unicode code point
 #^^^^^^ source.sentinel
 #      ^ source.sentinel keyword.operator.symbol.sentinel
@@ -143,10 +150,12 @@
 #         ^^^^^^^^^^ source.sentinel string.quoted.double.untitled constant.character.escape.unicode64.sentinel
 #                   ^ source.sentinel string.quoted.double.untitled
 #                    ^^^^^^^^^ source.sentinel
-#                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                             ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >
 ># Conversions
-#^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
+#^ source.sentinel comment.line.number-sign.sentinel punctuation.definition.comment.sentinel
+# ^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
 >value = int(42)   // 42
 #^^^^^^ source.sentinel
 #      ^ source.sentinel keyword.operator.symbol.sentinel
@@ -155,7 +164,8 @@
 #           ^ source.sentinel
 #            ^^ source.sentinel constant.numeric.number.sentinel
 #              ^^^^ source.sentinel
-#                  ^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                  ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                    ^^^ source.sentinel comment.line.double-slash.sentinel
 >value = int("42") // 42
 #^^^^^^ source.sentinel
 #      ^ source.sentinel keyword.operator.symbol.sentinel
@@ -166,7 +176,8 @@
 #             ^^ source.sentinel string.quoted.double.untitled
 #               ^ source.sentinel string.quoted.double.untitled
 #                ^^ source.sentinel
-#                  ^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                  ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                    ^^^ source.sentinel comment.line.double-slash.sentinel
 >value = int(42.8) // 42
 #^^^^^^ source.sentinel
 #      ^ source.sentinel keyword.operator.symbol.sentinel
@@ -175,7 +186,8 @@
 #           ^ source.sentinel
 #            ^^^^ source.sentinel constant.numeric.number.sentinel
 #                ^^ source.sentinel
-#                  ^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                  ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                    ^^^ source.sentinel comment.line.double-slash.sentinel
 >value = int(true) // 1
 #^^^^^^ source.sentinel
 #      ^ source.sentinel keyword.operator.symbol.sentinel
@@ -184,7 +196,8 @@
 #           ^ source.sentinel
 #            ^^^^ source.sentinel constant.language.sentinel
 #                ^^ source.sentinel
-#                  ^^^^ source.sentinel comment.line.double-slash.sentinel
+#                  ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                    ^^ source.sentinel comment.line.double-slash.sentinel
 >
 >value = float(1.2)   // 1.2
 #^^^^^^ source.sentinel
@@ -194,7 +207,8 @@
 #             ^ source.sentinel
 #              ^^^ source.sentinel constant.numeric.number.sentinel
 #                 ^^^^ source.sentinel
-#                     ^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                     ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                       ^^^^ source.sentinel comment.line.double-slash.sentinel
 >value = float(1)     // 1.0
 #^^^^^^ source.sentinel
 #      ^ source.sentinel keyword.operator.symbol.sentinel
@@ -203,7 +217,8 @@
 #             ^ source.sentinel
 #              ^ source.sentinel constant.numeric.number.sentinel
 #               ^^^^^^ source.sentinel
-#                     ^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                     ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                       ^^^^ source.sentinel comment.line.double-slash.sentinel
 >value = float("4.2") // 4.2
 #^^^^^^ source.sentinel
 #      ^ source.sentinel keyword.operator.symbol.sentinel
@@ -214,7 +229,8 @@
 #               ^^^ source.sentinel string.quoted.double.untitled
 #                  ^ source.sentinel string.quoted.double.untitled
 #                   ^^ source.sentinel
-#                     ^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                     ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                       ^^^^ source.sentinel comment.line.double-slash.sentinel
 >value = float(true)  // 1.0
 #^^^^^^ source.sentinel
 #      ^ source.sentinel keyword.operator.symbol.sentinel
@@ -223,7 +239,8 @@
 #             ^ source.sentinel
 #              ^^^^ source.sentinel constant.language.sentinel
 #                  ^^^ source.sentinel
-#                     ^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                     ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                       ^^^^ source.sentinel comment.line.double-slash.sentinel
 >
 >value = string("foo") // "foo"
 #^^^^^^ source.sentinel
@@ -235,7 +252,8 @@
 #                ^^^ source.sentinel string.quoted.double.untitled
 #                   ^ source.sentinel string.quoted.double.untitled
 #                    ^^ source.sentinel
-#                      ^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                      ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                        ^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >value = string(88)    // "88"
 #^^^^^^ source.sentinel
 #      ^ source.sentinel keyword.operator.symbol.sentinel
@@ -244,7 +262,8 @@
 #              ^ source.sentinel
 #               ^^ source.sentinel constant.numeric.number.sentinel
 #                 ^^^^^ source.sentinel
-#                      ^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                      ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                        ^^^^^ source.sentinel comment.line.double-slash.sentinel
 >value = string(0xF)   // "15"
 #^^^^^^ source.sentinel
 #      ^ source.sentinel keyword.operator.symbol.sentinel
@@ -253,7 +272,8 @@
 #              ^ source.sentinel
 #               ^^^ source.sentinel constant.numeric.hex.sentinel
 #                  ^^^^ source.sentinel
-#                      ^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                      ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                        ^^^^^ source.sentinel comment.line.double-slash.sentinel
 >value = string(true)  // "true"
 #^^^^^^ source.sentinel
 #      ^ source.sentinel keyword.operator.symbol.sentinel
@@ -262,7 +282,8 @@
 #              ^ source.sentinel
 #               ^^^^ source.sentinel constant.language.sentinel
 #                   ^^^ source.sentinel
-#                      ^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                      ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                        ^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >
 >value = bool("true")  // true
 #^^^^^^ source.sentinel
@@ -274,7 +295,8 @@
 #              ^^^^ source.sentinel string.quoted.double.untitled
 #                  ^ source.sentinel string.quoted.double.untitled
 #                   ^^^ source.sentinel
-#                      ^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                      ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                        ^^^^^ source.sentinel comment.line.double-slash.sentinel
 >value = bool(1)       // true
 #^^^^^^ source.sentinel
 #      ^ source.sentinel keyword.operator.symbol.sentinel
@@ -283,7 +305,8 @@
 #            ^ source.sentinel
 #             ^ source.sentinel constant.numeric.number.sentinel
 #              ^^^^^^^^ source.sentinel
-#                      ^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                      ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                        ^^^^^ source.sentinel comment.line.double-slash.sentinel
 >value = bool(-1)      // true
 #^^^^^^ source.sentinel
 #      ^ source.sentinel keyword.operator.symbol.sentinel
@@ -293,7 +316,8 @@
 #             ^ source.sentinel keyword.operator.symbol.sentinel
 #              ^ source.sentinel constant.numeric.number.sentinel
 #               ^^^^^^^ source.sentinel
-#                      ^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                      ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                        ^^^^^ source.sentinel comment.line.double-slash.sentinel
 >value = bool(0.1)     // true
 #^^^^^^ source.sentinel
 #      ^ source.sentinel keyword.operator.symbol.sentinel
@@ -302,7 +326,8 @@
 #            ^ source.sentinel
 #             ^^^ source.sentinel constant.numeric.number.sentinel
 #                ^^^^^^ source.sentinel
-#                      ^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                      ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                        ^^^^^ source.sentinel comment.line.double-slash.sentinel
 >value = bool("false") // false
 #^^^^^^ source.sentinel
 #      ^ source.sentinel keyword.operator.symbol.sentinel
@@ -313,7 +338,8 @@
 #              ^^^^^ source.sentinel string.quoted.double.untitled
 #                   ^ source.sentinel string.quoted.double.untitled
 #                    ^^ source.sentinel
-#                      ^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                      ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                        ^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >value = bool(0)       // false
 #^^^^^^ source.sentinel
 #      ^ source.sentinel keyword.operator.symbol.sentinel
@@ -322,5 +348,6 @@
 #            ^ source.sentinel
 #             ^ source.sentinel constant.numeric.number.sentinel
 #              ^^^^^^^^ source.sentinel
-#                      ^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#                      ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                        ^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >

--- a/tests/snapshot/sentinel/variables.sentinel.snap
+++ b/tests/snapshot/sentinel/variables.sentinel.snap
@@ -57,7 +57,8 @@
 #  ^ source.sentinel keyword.operator.symbol.sentinel
 #   ^ source.sentinel
 #    ^^^ source.sentinel support.function.builtin.sentinel
-#       ^^^^^^ source.sentinel
+#       ^ source.sentinel
+#        ^^^^^ source.sentinel
 #             ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
 #               ^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >a = float(s) // a = 1.1
@@ -65,7 +66,8 @@
 #  ^ source.sentinel keyword.operator.symbol.sentinel
 #   ^ source.sentinel
 #    ^^^^^ source.sentinel support.function.builtin.sentinel
-#         ^^^^ source.sentinel
+#         ^ source.sentinel
+#          ^^^ source.sentinel
 #             ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
 #               ^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >
@@ -79,7 +81,8 @@
 #  ^ source.sentinel keyword.operator.symbol.sentinel
 #   ^ source.sentinel
 #    ^^^^^^ source.sentinel support.function.builtin.sentinel
-#          ^^^^ source.sentinel
+#          ^ source.sentinel
+#           ^^^ source.sentinel
 #              ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
 #                ^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >

--- a/tests/snapshot/sentinel/variables.sentinel.snap
+++ b/tests/snapshot/sentinel/variables.sentinel.snap
@@ -1,5 +1,6 @@
 ># https://developer.hashicorp.com/sentinel/docs/language/variables
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
+#^ source.sentinel comment.line.number-sign.sentinel punctuation.definition.comment.sentinel
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.number-sign.sentinel
 >
 >a = 1       // a = 1
 #^^ source.sentinel
@@ -7,12 +8,14 @@
 #   ^ source.sentinel
 #    ^ source.sentinel constant.numeric.number.sentinel
 #     ^^^^^^^ source.sentinel
-#            ^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#            ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#              ^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >b = a       // b = 1
 #^^ source.sentinel
 #  ^ source.sentinel keyword.operator.symbol.sentinel
 #   ^^^^^^^^^ source.sentinel
-#            ^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#            ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#              ^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >a = "value" // a = "value", b = 1
 #^^ source.sentinel
 #  ^ source.sentinel keyword.operator.symbol.sentinel
@@ -21,18 +24,21 @@
 #     ^^^^^ source.sentinel string.quoted.double.untitled
 #          ^ source.sentinel string.quoted.double.untitled
 #           ^ source.sentinel
-#            ^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#            ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#              ^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >c = a       // c = "value", b = 1
 #^^ source.sentinel
 #  ^ source.sentinel keyword.operator.symbol.sentinel
 #   ^^^^^^^^^ source.sentinel
-#            ^^^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#            ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#              ^^^^^^^^^^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >
 >a = c // Error!
 #^^ source.sentinel
 #  ^ source.sentinel keyword.operator.symbol.sentinel
 #   ^^^ source.sentinel
-#      ^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#      ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#        ^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >c = 1
 #^^ source.sentinel
 #  ^ source.sentinel keyword.operator.symbol.sentinel
@@ -52,14 +58,16 @@
 #   ^ source.sentinel
 #    ^^^ source.sentinel support.function.builtin.sentinel
 #       ^^^^^^ source.sentinel
-#             ^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#             ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#               ^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >a = float(s) // a = 1.1
 #^^ source.sentinel
 #  ^ source.sentinel keyword.operator.symbol.sentinel
 #   ^ source.sentinel
 #    ^^^^^ source.sentinel support.function.builtin.sentinel
 #         ^^^^ source.sentinel
-#             ^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#             ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#               ^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >
 >a = 1
 #^^ source.sentinel
@@ -72,5 +80,6 @@
 #   ^ source.sentinel
 #    ^^^^^^ source.sentinel support.function.builtin.sentinel
 #          ^^^^ source.sentinel
-#              ^^^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
+#              ^^ source.sentinel comment.line.double-slash.sentinel punctuation.definition.comment.sentinel
+#                ^^^^^^^^ source.sentinel comment.line.double-slash.sentinel
 >


### PR DESCRIPTION
This PR updates the Sentinel Syntax Highlighting:

* Moves to an easier to understand "repository" style location for types of matches. This is similar to the TF syntax
* Updates the inbuilt function matching to NOT highlight non-function call locations e.g.

```
append(foo, bar)    <-- Highlight "append"
append = 2          <-- Do not highlight as it's not a function call
```

* Adds missing builtin function compare
* Fixes highlighting double symbol operators e.g. `==`
* Highlights triple and double word operators better e.g. `is not empty`

---

Note this PR should be squash merged