### PR TITLE
(TFECO-7531) fix(hcl): don't parse expressions containing an open curly brace as blocks

### DIFF
--- a/src/_main.yml
+++ b/src/_main.yml
@@ -76,7 +76,7 @@ repository:
   block:
     name: meta.block.hcl
     comment: This will match HCL blocks like `thing1 "one" "two" {` or `thing2 {`
-    begin: ([\w][\-\w]*)([^?\r\n]*)(\{)
+    begin: ([\w][\-\w]*)(([^\S\r\n]*([\w][\-_\w]*|\"[^\"\r\n]*\"))*)[^\S\r\n]*(\{)
     beginCaptures:
       "1":
         patterns:
@@ -89,9 +89,9 @@ repository:
             comment: Block label (String Literal)
             match: '\"[^\"\r\n]*\"'
           - name: variable.other.enummember.hcl
-            comment: Block label (Indentifier)
+            comment: Block label (Identifier)
             match: "[[:alpha:]][[:alnum:]_-]*"
-      "3":
+      "5":
         name: punctuation.section.block.begin.hcl
     end: \}
     endCaptures:

--- a/syntaxes/hcl.tmGrammar.json
+++ b/syntaxes/hcl.tmGrammar.json
@@ -82,7 +82,7 @@
     },
     "block": {
       "name": "meta.block.hcl",
-      "begin": "([\\w][\\-\\w]*)([^?\\r\\n]*)(\\{)",
+      "begin": "([\\w][\\-\\w]*)(([^\\S\\r\\n]*([\\w][\\-_\\w]*|\\\"[^\\\"\\r\\n]*\\\"))*)[^\\S\\r\\n]*(\\{)",
       "end": "\\}",
       "comment": "This will match HCL blocks like `thing1 \"one\" \"two\" {` or `thing2 {`",
       "beginCaptures": {
@@ -104,12 +104,12 @@
             },
             {
               "match": "[[:alpha:]][[:alnum:]_-]*",
-              "comment": "Block label (Indentifier)",
+              "comment": "Block label (Identifier)",
               "name": "variable.other.enummember.hcl"
             }
           ]
         },
-        "3": {
+        "5": {
           "name": "punctuation.section.block.begin.hcl"
         }
       },

--- a/syntaxes/terraform.tmGrammar.json
+++ b/syntaxes/terraform.tmGrammar.json
@@ -112,6 +112,9 @@
         },
         "3": {
           "name": "punctuation.section.block.begin.hcl"
+        },
+        "5": {
+          "name": "punctuation.section.block.begin.hcl"
         }
       },
       "endCaptures": {

--- a/tests/snapshot/hcl/block_labels.hcl
+++ b/tests/snapshot/hcl/block_labels.hcl
@@ -49,6 +49,10 @@ block-single-char-indentifier-newline a {
 byte_match_statement_rules = local.enabled && var.byte_match_statement_rules != null ? {
 }
 
+# braces are fun (now)
+a = not_a_block == "{"
+brace_label "{" {}
+
 path "secrets/data/users/{{identity.entity.name}}/*" {
   capabilities = ["create", "update", "patch", "read", "delete", "list"]
 }

--- a/tests/snapshot/hcl/block_labels.hcl.snap
+++ b/tests/snapshot/hcl/block_labels.hcl.snap
@@ -266,6 +266,28 @@
 >}
 #^ source.hcl meta.braces.hcl punctuation.section.braces.end.hcl
 >
+># braces are fun (now)
+#^ source.hcl comment.line.number-sign.hcl punctuation.definition.comment.hcl
+# ^^^^^^^^^^^^^^^^^^^^^ source.hcl comment.line.number-sign.hcl
+>a = not_a_block == "{"
+#^ source.hcl variable.declaration.hcl variable.other.readwrite.hcl
+# ^ source.hcl variable.declaration.hcl
+#  ^ source.hcl variable.declaration.hcl keyword.operator.assignment.hcl
+#   ^ source.hcl variable.declaration.hcl
+#    ^^^^^^^^^^^^ source.hcl
+#                ^^ source.hcl keyword.operator.hcl
+#                  ^ source.hcl
+#                   ^ source.hcl string.quoted.double.hcl punctuation.definition.string.begin.hcl
+#                    ^ source.hcl string.quoted.double.hcl
+#                     ^ source.hcl string.quoted.double.hcl punctuation.definition.string.end.hcl
+>brace_label "{" {}
+#^^^^^^^^^^^ source.hcl meta.block.hcl entity.name.type.hcl
+#           ^ source.hcl meta.block.hcl
+#            ^^^ source.hcl meta.block.hcl variable.other.enummember.hcl
+#               ^ source.hcl meta.block.hcl
+#                ^ source.hcl meta.block.hcl punctuation.section.block.begin.hcl
+#                 ^ source.hcl meta.block.hcl punctuation.section.block.end.hcl
+>
 >path "secrets/data/users/{{identity.entity.name}}/*" {
 #^^^^ source.hcl meta.block.hcl entity.name.type.hcl
 #    ^ source.hcl meta.block.hcl


### PR DESCRIPTION
This fixes the following problem in Terraform Test files (which use the HCL syntax instead of the more specialized Terraform one):
<img width="796" alt="image" src="https://github.com/user-attachments/assets/58e075d1-d139-458d-bf29-0f476b9162a4">
The grammar treats the opening brace that is part of the template string as a block and therefore breaks the following lines (mostly treated as a string).

This PR restricts parsing blocks as it only allows block labels to contain any character if that label is enclosed by double quotes. If it isn't only `\w-_` are valid characters.