### PR TITLE
Fix catastrophic backtracking of whitespaces in blocks

### DIFF
--- a/src/_main.yml
+++ b/src/_main.yml
@@ -76,7 +76,7 @@ repository:
   block:
     name: meta.block.hcl
     comment: This will match HCL blocks like `thing1 "one" "two" {` or `thing2 {`
-    begin: ([\w][\-\w]*)(([^\S\r\n]*([\w][\-_\w]*|\"[^\"\r\n]*\"))*)[^\S\r\n]*(\{)
+    begin: ([\w][\-\w]*)(([^\S\r\n]+([\w][\-_\w]*|\"[^\"\r\n]*\"))*)[^\S\r\n]*(\{)
     beginCaptures:
       "1":
         patterns:

--- a/syntaxes/hcl.tmGrammar.json
+++ b/syntaxes/hcl.tmGrammar.json
@@ -82,7 +82,7 @@
     },
     "block": {
       "name": "meta.block.hcl",
-      "begin": "([\\w][\\-\\w]*)(([^\\S\\r\\n]*([\\w][\\-_\\w]*|\\\"[^\\\"\\r\\n]*\\\"))*)[^\\S\\r\\n]*(\\{)",
+      "begin": "([\\w][\\-\\w]*)(([^\\S\\r\\n]+([\\w][\\-_\\w]*|\\\"[^\\\"\\r\\n]*\\\"))*)[^\\S\\r\\n]*(\\{)",
       "end": "\\}",
       "comment": "This will match HCL blocks like `thing1 \"one\" \"two\" {` or `thing2 {`",
       "beginCaptures": {


### PR DESCRIPTION
Solved #164 
<details><summary>Issue Details</summary>

I upgraded [Shiki](https://shiki.matsu.io/) version to one that came after [this](https://github.com/hashicorp/syntax/commit/cc2b4d4fe389f14b8a13937f4e0d7b2811b57588#diff-483a7704bb65e7c8a156f5990c81c83143f3e4204744d1a86616cd0fc9c452c0R85) change and It caused tabs with HCL code blocks to freeze.
It turned out there is a **"catastrophic backtracking"** in that regex because:  
`[^\S\r\n]*` could match zero characters, which makes the number of possibilities grow exponentially.
Here's a demonstration of it:
https://regex101.com/r/9vmzvg/2/debugger

I'm not sure if it can cause a DDOS on servers that highlighting with this syntax, it's not so noticeable on fast engines like Onigurama, but it's caused JS engines to be not usable like Shiki in [this example](https://textmate-grammars-themes.netlify.app/?grammar=hcl&theme=github-dark&code=var+%3D+%5B%22Every%22%2C+%22Item%22%2C+%22Slows%22%2C+%22Down%22%2C+%22Everything%22%5D)
</details> 



### Solution
Replace that `*` by `+` solves the issue and all the tests pass 🙂